### PR TITLE
Fix cross-platform help command and improve diff messages

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -12,6 +12,9 @@ func init() {
 	// io.Writer using fmt.Fprint.  This avoids any OS-specific pager or
 	// man-page lookup and ensures --help works identically on Windows,
 	// macOS, and Linux.
+	// HelpPrinterCustom renders the help template directly into w via
+	// text/template.Execute — no external pager, man-page, or shell command
+	// is invoked, which is what makes this safe on Windows/PowerShell.
 	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
 		cli.HelpPrinterCustom(w, templ, data, nil)
 	}

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -2,9 +2,20 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/urfave/cli/v2"
 )
+
+func init() {
+	// Override the default HelpPrinter to write directly to the provided
+	// io.Writer using fmt.Fprint.  This avoids any OS-specific pager or
+	// man-page lookup and ensures --help works identically on Windows,
+	// macOS, and Linux.
+	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+		cli.HelpPrinterCustom(w, templ, data, nil)
+	}
+}
 
 // Handlers contains injected command actions so CLI wiring can live outside main.
 type Handlers struct {

--- a/internal/appcore/review_runtime.go
+++ b/internal/appcore/review_runtime.go
@@ -170,7 +170,7 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 			return fmt.Errorf("failed to collect diff for vouch: %w", diffErr)
 		}
 		if len(diffContent) == 0 {
-			return fmt.Errorf("no diff content to vouch for")
+			return fmt.Errorf("%s", noDiffMessage(opts.DiffSource))
 		}
 		parsedFiles, parseErr := parseDiffToFiles(diffContent)
 		if parseErr != nil {
@@ -271,7 +271,7 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 	}
 
 	if len(diffContent) == 0 {
-		return fmt.Errorf("no diff content collected")
+		return fmt.Errorf("%s", noDiffMessage(opts.DiffSource))
 	}
 
 	var fakeBaseFiles []reviewmodel.DiffReviewFileResult
@@ -1365,6 +1365,25 @@ func collectDiffWithOptions(opts reviewopts.Options) ([]byte, error) {
 
 	default:
 		return nil, fmt.Errorf("invalid diff-source: %s (must be staged, working, commit, range, or file)", diffSource)
+	}
+}
+
+// noDiffMessage returns a beginner-friendly error string tailored to the
+// diff source that produced no content.
+func noDiffMessage(diffSource string) string {
+	switch diffSource {
+	case "staged":
+		return "No staged changes found. Please stage your files using `git add <file>` before running a review."
+	case "working":
+		return "No working-tree changes found. Make some edits before running a review."
+	case "commit":
+		return "The specified commit(s) produced an empty diff. Verify the commit reference and try again."
+	case "range":
+		return "The specified range produced an empty diff. Verify the range and try again."
+	case "file":
+		return "The provided diff file is empty. Provide a non-empty diff file."
+	default:
+		return "No diff content collected."
 	}
 }
 


### PR DESCRIPTION

This pull request improves the user experience when no diff content is found during a review and enhances cross-platform help output consistency. The most important changes include providing more beginner-friendly, context-aware error messages when no diff is available, and ensuring help output works identically across operating systems.

User experience improvements for empty diffs:

* Added a new `noDiffMessage` function in `review_runtime.go` to generate tailored, beginner-friendly error messages depending on the diff source (e.g., staged, working, commit, range, file). This replaces generic error messages when no diff content is found.
* Updated error handling in `runReviewWithOptions` to use the new `noDiffMessage` function for both vouch and main diff collection paths, ensuring users receive clear instructions on what to do next. [[1]](diffhunk://#diff-fd7cb4778a43740cbf15e54cc1e7b3aed2ee032d531d8149044cb7ccf0c24224L173-R173) [[2]](diffhunk://#diff-fd7cb4778a43740cbf15e54cc1e7b3aed2ee032d531d8149044cb7ccf0c24224L274-R274)

Cross-platform CLI help consistency:

* Overrode the default `HelpPrinter` in `cmd/app.go` to use `HelpPrinterCustom`, ensuring that `--help` output is rendered directly to the terminal without invoking any external pagers or shell commands. This guarantees identical behavior on Windows, macOS, and Linux.