### PR TITLE
Add GitHub Codespaces authentication flow support and fix callback URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ curl -fsSL https://hexmos.com/lrc-install.sh | bash
 iwr -useb https://hexmos.com/lrc-install.ps1 | iex
 ```
 
+<details>
+<summary><strong>GitHub Codespaces</strong></summary>
+
+```bash
+curl -fsSL https://git.new/lrc-install | bash
+```
+
+</details>
+
 Binary installed. Hooks set up globally. Done.
 
 ### Setup

--- a/internal/appui/setup_flow.go
+++ b/internal/appui/setup_flow.go
@@ -218,6 +218,16 @@ func backupExistingConfig(slog *setupLog) error {
 	return nil
 }
 
+// isCodespace returns the public HTTPS callback URL for GitHub Codespaces
+func isCodespace(port int) (string, bool) {
+	name := os.Getenv("CODESPACE_NAME")
+	domain := os.Getenv("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN")
+	if name == "" || domain == "" {
+		return "", false
+	}
+	return fmt.Sprintf("https://%s-%d.%s/callback", name, port, domain), true
+}
+
 // runHexmosLoginFlow starts a temporary server, opens the browser for Hexmos Login,
 // waits for the callback, and provisions the user in LiveReview.
 func runHexmosLoginFlow(slog *setupLog, apiURL string) (*setupResult, error) {
@@ -227,6 +237,9 @@ func runHexmosLoginFlow(slog *setupLog, apiURL string) (*setupResult, error) {
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
 	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+	if csURL, ok := isCodespace(port); ok {
+		callbackURL = csURL
+	}
 
 	dataCh := make(chan *hexmosCallbackData, 1)
 	errCh := make(chan error, 1)

--- a/setup/login_server.go
+++ b/setup/login_server.go
@@ -16,7 +16,7 @@ func BuildSigninURL(callbackURL string) (string, error) {
 	if cbURL.Scheme != "http" && cbURL.Scheme != "https" {
 		return "", fmt.Errorf("invalid callback url scheme: %s", cbURL.Scheme)
 	}
-	if cbURL.Hostname() != "127.0.0.1" && cbURL.Hostname() != "localhost" {
+	if cbURL.Scheme == "http" && cbURL.Hostname() != "127.0.0.1" && cbURL.Hostname() != "localhost" {
 		return "", fmt.Errorf("callback url must use localhost/127.0.0.1")
 	}
 


### PR DESCRIPTION

## Readme Update
- In the readme, added instruction for  installing git-lrc in GitHub Codespaces under direct install

## Code Fix
- detect Codespaces env and use port-forwarding URL as OAuth callback for fixing the authentication issue in `git lrc setup`