### PR TITLE
Implement Claude Code handoff 

### DIFF
--- a/internal/appcore/interactive_decision.go
+++ b/internal/appcore/interactive_decision.go
@@ -3,9 +3,12 @@ package appcore
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/HexmosTech/git-lrc/internal/decisionflow"
+	"github.com/HexmosTech/git-lrc/internal/reviewapi"
 	"github.com/urfave/cli/v2"
 )
 
@@ -98,6 +101,38 @@ func executeDecision(code int, message string, push bool, ctx decisionExecutionC
 			return err
 		}
 		return nil
+	case decisionflow.DecisionHandoff:
+		syncedPrintln("\n🤖 Handing off Claude Code...")
+
+		gitDir, err := reviewapi.ResolveGitDir()
+		if err != nil {
+			return fmt.Errorf("failed to resolve git directory: %w", err)
+		}
+
+		reviewDir := filepath.Join(gitDir, "lrc", "reviews", ctx.reviewID)
+		if err := os.MkdirAll(reviewDir, 0755); err != nil {
+			return fmt.Errorf("failed to create review directory: %w", err)
+		}
+
+		jsonPath := filepath.Join(reviewDir, "review_findings.json")
+		if err := os.WriteFile(jsonPath, []byte(message), 0644); err != nil {
+			return fmt.Errorf("failed to write review findings: %w", err)
+		}
+
+		promptMsg := fmt.Sprintf("Read %s. This JSON contains code review feedback on my recent changes. The 'hunks' show the current buggy code, and 'comments' explain the issues. Please modify the source files in this workspace to fix the errors mentioned in the comments. Do not treat the 'hunks' as the solution. Briefly explain what you fixed, and then politely remind me that I can type /exit to close this session.", jsonPath)
+		cmdArgs := []string{promptMsg}
+		syncedPrintln("🚀 Running: claude code")
+
+		cmd := exec.Command("claude", cmdArgs...)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("claude agent failed: %w", err)
+		}
+
+		return cli.Exit("", 0) // exit cleanly after fix
 	default:
 		return fmt.Errorf("invalid decision code: %d", code)
 	}

--- a/internal/appcore/interactive_decision.go
+++ b/internal/appcore/interactive_decision.go
@@ -119,7 +119,7 @@ func executeDecision(code int, message string, push bool, ctx decisionExecutionC
 			return fmt.Errorf("failed to write review findings: %w", err)
 		}
 
-		promptMsg := fmt.Sprintf("Read %s. This JSON contains code review feedback on my recent changes. The 'hunks' show the current buggy code, and 'comments' explain the issues. Please modify the source files in this workspace to fix the errors mentioned in the comments. Do not treat the 'hunks' as the solution. Briefly explain what you fixed, and then politely remind me that I can type /exit to close this session.", jsonPath)
+		promptMsg := fmt.Sprintf(ClaudeHandoffPromptTemplate, jsonPath)
 		cmdArgs := []string{promptMsg}
 		syncedPrintln("🚀 Running: claude code")
 

--- a/internal/appcore/interactive_decision.go
+++ b/internal/appcore/interactive_decision.go
@@ -102,7 +102,7 @@ func executeDecision(code int, message string, push bool, ctx decisionExecutionC
 		}
 		return nil
 	case decisionflow.DecisionHandoff:
-		syncedPrintln("\n🤖 Handing off Claude Code...")
+		syncedPrintln("\n🤖 Handing off to Claude Code...")
 
 		gitDir, err := reviewapi.ResolveGitDir()
 		if err != nil {

--- a/internal/appcore/prompt.go
+++ b/internal/appcore/prompt.go
@@ -1,0 +1,3 @@
+package appcore
+
+const ClaudeHandoffPromptTemplate = `Read %s. This JSON contains code review feedback on my recent changes. The 'hunks' show the current buggy code, and 'comments' explain the issues. Please modify the source files in this workspace to fix the errors mentioned in the comments. Do not treat the 'hunks' as the solution. Briefly explain what you fixed, and then politely remind me that I can type /exit to close this session.`

--- a/internal/appcore/review_runtime.go
+++ b/internal/appcore/review_runtime.go
@@ -659,7 +659,11 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
 				}
-				body, _ := io.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, "Failed to read request body", http.StatusBadRequest)
+					return
+				}
 				handleProgressiveDecision(w, decisionflow.DecisionHandoff, string(body), false)
 			})
 			// Proxy endpoint for review-events API to avoid CORS
@@ -2678,7 +2682,11 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read request body", http.StatusBadRequest)
+			return
+		}
 		handleDecision(w, decisionflow.DecisionHandoff, string(body), false)
 	})
 

--- a/internal/appcore/review_runtime.go
+++ b/internal/appcore/review_runtime.go
@@ -654,6 +654,14 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 				}
 				handleProgressiveDecision(w, decisionflow.DecisionAbort, "", false)
 			})
+			mux.HandleFunc("/handoff", func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				body, _ := io.ReadAll(r.Body)
+				handleProgressiveDecision(w, decisionflow.DecisionHandoff, string(body), false)
+			})
 			// Proxy endpoint for review-events API to avoid CORS
 			mux.HandleFunc("/api/v1/diff-review/", func(w http.ResponseWriter, r *http.Request) {
 				if fakeMode {
@@ -2663,6 +2671,15 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 		}
 		draftState.Freeze()
 		handleDecision(w, decisionflow.DecisionAbort, "", false)
+	})
+
+	mux.HandleFunc("/handoff", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		handleDecision(w, decisionflow.DecisionHandoff, string(body), false)
 	})
 
 	// Start server in background using the already-open listener

--- a/internal/decisionflow/decisionflow.go
+++ b/internal/decisionflow/decisionflow.go
@@ -6,10 +6,11 @@ import (
 )
 
 const (
-	DecisionCommit = 0 // proceed with commit
-	DecisionAbort  = 1 // abort commit
-	DecisionSkip   = 2 // skip review, proceed with commit
-	DecisionVouch  = 4 // vouch for changes, proceed with commit
+	DecisionCommit  = 0 // proceed with commit
+	DecisionAbort   = 1 // abort commit
+	DecisionSkip    = 2 // skip review, proceed with commit
+	DecisionVouch   = 4 // vouch for changes, proceed with commit
+	DecisionHandoff = 5 // handoff to AI agent
 )
 
 type Phase int
@@ -25,7 +26,7 @@ func ActionAllowedInPhase(code int, phase Phase) bool {
 		return true
 	case DecisionSkip, DecisionVouch:
 		return phase == PhaseReviewRunning
-	case DecisionCommit:
+	case DecisionCommit, DecisionHandoff:
 		return phase == PhaseReviewComplete
 	default:
 		return false

--- a/internal/staticserve/static/app.js
+++ b/internal/staticserve/static/app.js
@@ -468,7 +468,7 @@ async function initApp() {
                 ...reviewData,
                 files: filteredFiles,
                 Files: filteredFiles,
-                summary: "AI Agent Handoff generated for selected issues.",
+                summary: "AI Agent Handoff generated for visible issues.",
                 status: "completed"
             };
             
@@ -811,11 +811,19 @@ async function initApp() {
                         <div class="modal-overlay" style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.7); z-index: 9999; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(4px);">
                             <div class="modal-content" style="background: var(--bg-card); padding: 32px; border-radius: 12px; max-width: 400px; width: 90%; border: 1px solid var(--border-color); box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5); text-align: center;">
                                 ${handoffModal.type === 'success' 
-                                    ? html`<div style="font-size: 48px; margin-bottom: 16px;">🚀</div>`
+                                    ? html`
+                                        <div style="margin-bottom: 16px; color: #8b5cf6;">
+                                            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                                <rect x="2" y="3" width="20" height="18" rx="2" ry="2"></rect>
+                                                <polyline points="6 8 10 12 6 16"></polyline>
+                                                <line x1="14" y1="16" x2="18" y2="16"></line>
+                                            </svg>
+                                        </div>
+                                    `
                                     : html`<div style="font-size: 48px; margin-bottom: 16px;">⚠️</div>`
                                 }
                                 <h3 style="margin: 0 0 12px 0; font-size: 20px; color: var(--text-primary);">
-                                    ${handoffModal.type === 'success' ? 'Handoff Successful' : 'Notice'}
+                                    ${handoffModal.type === 'success' ? 'Check Your Terminal' : 'Notice'}
                                 </h3>
                                 <p style="margin: 0 0 24px 0; color: var(--text-secondary); line-height: 1.5;">
                                     ${handoffModal.message}

--- a/internal/staticserve/static/app.js
+++ b/internal/staticserve/static/app.js
@@ -442,6 +442,44 @@ async function initApp() {
             });
         }, []);
 
+        const handleSendToAgent = useCallback(async () => {
+            const filteredFiles = (reviewData.files || reviewData.Files || []).map(file => {
+                const filePath = file.file_path || file.filePath || file.FilePath;
+                const newComments = (file.comments || file.Comments || []).filter(c => {
+                    const sev = (c.severity || c.Severity || '').toLowerCase();
+                    if (!visibleSeverities.has(sev)) return false;
+                    const key = getCommentVisibilityKey(filePath, c);
+                    return !hiddenCommentKeys.has(key);
+                });
+                return { ...file, comments: newComments, Comments: newComments };
+            }).filter(file => file.comments.length > 0);
+            
+            if (filteredFiles.length === 0) {
+                alert("No visible comments to send to the AI agent. Please show some comments first.");
+                return;
+            }
+            
+            const payload = {
+                ...reviewData,
+                files: filteredFiles,
+                Files: filteredFiles,
+                summary: "AI Agent Handoff generated for selected issues.",
+                status: "completed"
+            };
+            
+            try {
+                const response = await fetch('/handoff', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                if (!response.ok) throw new Error("Handoff failed");
+                alert("Handoff successful! Claude Agent is now starting in your terminal.");
+            } catch (e) {
+                alert("Failed to send to agent: " + e.message);
+            }
+        }, [reviewData, visibleSeverities, hiddenCommentKeys]);
+
         const showCopyFeedback = useCallback((status, message) => {
             setCopyFeedback({ status, message });
             if (copyFeedbackTimerRef.current) {
@@ -614,6 +652,25 @@ async function initApp() {
         // Calculate totalComments from actual files - single source of truth
         const totalComments = files.reduce((sum, file) => sum + (file.CommentCount || 0), 0);
         
+        // Calculate visible comments for the agent button
+        let totalVisibleComments = 0;
+        files.forEach(file => {
+            if (!file.HasComments) return;
+            file.Hunks.forEach(hunk => {
+                hunk.Lines.forEach(line => {
+                    if (line.IsComment && line.Comments) {
+                        line.Comments.forEach((comment) => {
+                            const sev = (comment.Severity || '').toLowerCase();
+                            if (!visibleSeverities.has(sev)) return;
+                            const visibilityKey = getCommentVisibilityKey(file.FilePath, comment);
+                            if (visibilityKey && hiddenCommentKeys.has(visibilityKey)) return;
+                            totalVisibleComments++;
+                        });
+                    }
+                });
+            });
+        });
+        
         // Status display
         const getStatusDisplay = () => {
             if (reviewData?.blocked) {
@@ -708,6 +765,8 @@ async function initApp() {
                             hiddenCommentKeys=${hiddenCommentKeys}
                             copyFeedbackStatus=${copyFeedback.status}
                             copyFeedbackMessage=${copyFeedback.message}
+                            onSendToAgent=${handleSendToAgent}
+                            visibleCount=${totalVisibleComments}
                         />
                     `}
                     

--- a/internal/staticserve/static/app.js
+++ b/internal/staticserve/static/app.js
@@ -197,6 +197,7 @@ async function initApp() {
         const [isTailing, setIsTailing] = useState(false);
         const [hiddenCommentKeys, setHiddenCommentKeys] = useState(new Set());
         const [copyFeedback, setCopyFeedback] = useState({ status: 'idle', message: '' });
+        const [handoffModal, setHandoffModal] = useState({ isOpen: false, type: '', message: '' });
         
         const pollingRef = useRef(null);
         const eventsPollingRef = useRef(null);
@@ -455,7 +456,11 @@ async function initApp() {
             }).filter(file => file.comments.length > 0);
             
             if (filteredFiles.length === 0) {
-                alert("No visible comments to send to the AI agent. Please show some comments first.");
+                setHandoffModal({ 
+                    isOpen: true, 
+                    type: 'error', 
+                    message: "No visible comments to send to the AI agent. Please show some comments first." 
+                });
                 return;
             }
             
@@ -474,9 +479,17 @@ async function initApp() {
                     body: JSON.stringify(payload)
                 });
                 if (!response.ok) throw new Error("Handoff failed");
-                alert("Handoff successful! Claude Agent is now starting in your terminal.");
+                setHandoffModal({ 
+                    isOpen: true, 
+                    type: 'success', 
+                    message: "Claude Code is now starting in your terminal! You can safely close this browser window." 
+                });
             } catch (e) {
-                alert("Failed to send to agent: " + e.message);
+                setHandoffModal({ 
+                    isOpen: true, 
+                    type: 'error', 
+                    message: "Failed to send to agent: " + e.message 
+                });
             }
         }, [reviewData, visibleSeverities, hiddenCommentKeys]);
 
@@ -793,6 +806,30 @@ async function initApp() {
                             `
                         }
                     </div>
+                    
+                    ${handoffModal.isOpen && html`
+                        <div class="modal-overlay" style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.7); z-index: 9999; display: flex; align-items: center; justify-content: center; backdrop-filter: blur(4px);">
+                            <div class="modal-content" style="background: var(--bg-card); padding: 32px; border-radius: 12px; max-width: 400px; width: 90%; border: 1px solid var(--border-color); box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5); text-align: center;">
+                                ${handoffModal.type === 'success' 
+                                    ? html`<div style="font-size: 48px; margin-bottom: 16px;">🚀</div>`
+                                    : html`<div style="font-size: 48px; margin-bottom: 16px;">⚠️</div>`
+                                }
+                                <h3 style="margin: 0 0 12px 0; font-size: 20px; color: var(--text-primary);">
+                                    ${handoffModal.type === 'success' ? 'Handoff Successful' : 'Notice'}
+                                </h3>
+                                <p style="margin: 0 0 24px 0; color: var(--text-secondary); line-height: 1.5;">
+                                    ${handoffModal.message}
+                                </p>
+                                <button 
+                                    class="btn btn-primary" 
+                                    onClick=${() => setHandoffModal({ ...handoffModal, isOpen: false })}
+                                    style="width: 100%; padding: 12px; font-size: 16px;"
+                                >
+                                    ${handoffModal.type === 'success' ? 'Got it' : 'Close'}
+                                </button>
+                            </div>
+                        </div>
+                    `}
                     
                     <!-- Events Tab -->
                     <div id="events-tab" class="tab-content ${activeTab === 'events' ? 'active' : ''}" style="display: ${activeTab === 'events' ? 'block' : 'none'}">

--- a/internal/staticserve/static/components/Comment.js
+++ b/internal/staticserve/static/components/Comment.js
@@ -6,7 +6,7 @@ export async function createComment() {
     
     return function Comment({ comment, filePath, codeExcerpt, commentId, visibilityKey, isHidden, onToggleVisibility }) {
         const [copied, setCopied] = useState(false);
-        
+
         const handleCopy = async (e) => {
             e.stopPropagation();
             
@@ -52,24 +52,23 @@ export async function createComment() {
             <tr class="comment-row ${isHidden ? 'comment-row-hidden' : ''}" data-line="${comment.Line}" id="${commentId}">
                 <td colspan="3">
                     <div class="comment-visibility-row">
-                        <button 
-                            type="button"
-                            class="comment-visibility-toggle ${isHidden ? 'off' : 'on'}"
-                            title="${isHidden ? 'Show comment' : 'Hide comment'}"
-                            aria-pressed="${!isHidden}"
-                            onClick=${handleToggleVisibility}
-                        >
-                            ${isHidden 
-                                ? html`<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.94 17.94A10.07 10.07 0 0112 20c-5 0-9.27-3.11-11-7.5a11.8 11.8 0 012.89-4.11M9.88 9.88a3 3 0 104.24 4.24"/><path d="M1 1l22 22"/></svg>`
-                                : html`<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12z"/><circle cx="12" cy="12" r="3"/></svg>`
-                            }
-                        </button>
                         ${isHidden
                             ? html`
-                                <div class="comment-hidden-placeholder">
+                                <div class="comment-hidden-placeholder" style="position: relative;">
+                                    <div class="comment-actions" style="display: flex; gap: 8px; position: absolute; right: 12px; top: 12px;">
+                                        <button 
+                                            class="comment-visibility-btn"
+                                            title="Show this comment to the AI Agent"
+                                            onClick=${handleToggleVisibility}
+                                            style="position: static; opacity: 1;"
+                                        >
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12z"/><circle cx="12" cy="12" r="3"/></svg>
+                                            Show
+                                        </button>
+                                    </div>
                                     <span class="comment-hidden-title">Comment hidden</span>
                                     <span class="comment-hidden-meta">${filePath}${lineLabel}</span>
-                                    <span class="comment-hidden-note">Hidden comments are excluded from Copy Visible Issues.</span>
+                                    <span class="comment-hidden-note">Hidden comments are excluded from Copy Visible Issues and Claude Agent.</span>
                                 </div>
                             `
                             : html`
@@ -79,13 +78,25 @@ export async function createComment() {
                                     data-line="${comment.Line}"
                                     data-comment="${comment.Content}"
                                 >
-                                    <button 
-                                        class="comment-copy-btn ${copied ? 'copied' : ''}"
-                                        title="Copy issue details"
-                                        onClick=${handleCopy}
-                                    >
-                                        ${copied ? 'Copied!' : 'Copy'}
-                                    </button>
+                                    <div class="comment-actions" style="display: flex; gap: 8px; position: absolute; right: 12px; top: 12px;">
+                                        <button 
+                                            class="comment-visibility-btn"
+                                            title="Hide this comment from the AI Agent"
+                                            onClick=${handleToggleVisibility}
+                                            style="position: static; opacity: 1;"
+                                        >
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.94 17.94A10.07 10.07 0 0112 20c-5 0-9.27-3.11-11-7.5a11.8 11.8 0 012.89-4.11M9.88 9.88a3 3 0 104.24 4.24"/><path d="M1 1l22 22"/></svg>
+                                            Hide
+                                        </button>
+                                        <button 
+                                            class="comment-copy-btn ${copied ? 'copied' : ''}"
+                                            title="Copy issue details"
+                                            onClick=${handleCopy}
+                                            style="position: static;"
+                                        >
+                                            ${copied ? 'Copied!' : 'Copy'}
+                                        </button>
+                                    </div>
                                     <div class="comment-header">
                                         <span class="comment-badge ${badgeClass}">${comment.Severity}</span>
                                         ${comment.HasCategory && html`

--- a/internal/staticserve/static/components/Comment.js
+++ b/internal/staticserve/static/components/Comment.js
@@ -68,7 +68,7 @@ export async function createComment() {
                                     </div>
                                     <span class="comment-hidden-title">Comment hidden</span>
                                     <span class="comment-hidden-meta">${filePath}${lineLabel}</span>
-                                    <span class="comment-hidden-note">Hidden comments are excluded from Copy Visible Issues and Claude Agent.</span>
+                                    <span class="comment-hidden-note">Hidden comments are excluded from Copy Visible Issues and the Claude Agent.</span>
                                 </div>
                             `
                             : html`

--- a/internal/staticserve/static/components/SeverityFilter.js
+++ b/internal/staticserve/static/components/SeverityFilter.js
@@ -11,7 +11,9 @@ export async function createSeverityFilter() {
         onCopyVisibleIssues, 
         hiddenCommentKeys,
         copyFeedbackStatus,
-        copyFeedbackMessage
+        copyFeedbackMessage,
+        onSendToAgent,
+        visibleCount
     }) {
         const counts = countIssuesBySeverity(files, visibleSeverities, hiddenCommentKeys);
         if (counts.total === 0) return null;
@@ -66,7 +68,7 @@ export async function createSeverityFilter() {
                     </button>
                 </div>
                 <span class="severity-filter-summary">${filterLabel}</span>
-                <div class="copy-visible-wrapper">
+                <div class="copy-visible-wrapper" style="flex-direction: row; align-items: center; gap: 8px;">
                     <button 
                         class="btn btn-primary copy-visible-btn ${buttonState}"
                         onClick=${onCopyVisibleIssues} 
@@ -76,6 +78,13 @@ export async function createSeverityFilter() {
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                         </svg>
                         ${buttonLabel}
+                    </button>
+                    <button
+                        class="btn btn-primary"
+                        onClick=${onSendToAgent}
+                        title="Send visible issues to Claude"
+                    >
+                        Send to Claude (${visibleCount})
                     </button>
                     ${copyFeedbackMessage && html`
                         <div class="copy-feedback copy-feedback-${copyFeedbackStatus}" role="status" aria-live="polite">

--- a/internal/staticserve/static/styles.css
+++ b/internal/staticserve/static/styles.css
@@ -1082,6 +1082,27 @@ body {
     font-size: 12px;
 }
 
+.comment-visibility-btn {
+    background: rgba(139,92,246,0.15);
+    border: 1px solid rgba(139,92,246,0.3);
+    color: #c4b5fd;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.comment-visibility-btn:hover {
+    background: rgba(139,92,246,0.25);
+    border-color: rgba(139,92,246,0.5);
+    transform: scale(1.05);
+}
+
 .comment-copy-btn.copied {
     background: rgba(34,197,94,0.15);
     border-color: rgba(34,197,94,0.3);


### PR DESCRIPTION
This PR introduces a  workflow to visually filter git-lrc findings and hand them off to the Claude Code CLI for automatic, interactive code remediation

related discussion: https://github.com/HexmosTech/git-lrc/discussions/52


## Changes:

- Sent only visually shown comments to the AI agent instead of using manual checkboxes.
- Added a custom "Check Your Terminal" overlay modal to replace native browser alerts.
- Launched Claude interactively to safely prompt users for (y/n) write permissions.