### PR TITLE
Fix: Session based communication for UI with git-lrc internal server

### DIFF
--- a/internal/appcore/review_runtime.go
+++ b/internal/appcore/review_runtime.go
@@ -465,6 +465,9 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 		// Initialize global review state for API-based UI
 		reviewStateMu.Lock()
 		currentReviewState = NewReviewState(reviewID, filesFromDiff, useInteractive, isPostCommitReview, initialMsg, config.APIURL)
+		if submitResp.FriendlyName != "" {
+			currentReviewState.FriendlyName = submitResp.FriendlyName
+		}
 		if submissionFailed {
 			currentReviewState.Status = "failed"
 			currentReviewState.ErrorSummary = submissionBlockedReason

--- a/internal/appcore/review_runtime.go
+++ b/internal/appcore/review_runtime.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -481,7 +482,7 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 			opts.Port = selectedPort
 		}
 
-		serveURL := fmt.Sprintf("http://localhost:%d", opts.Port)
+		serveURL := fmt.Sprintf("http://localhost:%d/?r=%s", opts.Port, url.QueryEscape(reviewID))
 		if !useInteractive {
 			fmt.Printf("\n🌐 Review available at: %s\n", highlightURL(serveURL))
 			fmt.Printf("   Comments will appear progressively as review runs\n\n")
@@ -580,7 +581,7 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 			})
 
 			// API endpoint for review state - frontend polls this
-			mux.HandleFunc("/api/review", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/api/review", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 				reviewStateMu.RLock()
 				state := currentReviewState
 				reviewStateMu.RUnlock()
@@ -590,14 +591,14 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 					return
 				}
 				state.ServeHTTP(w, r)
-			})
+			}))
 
-			mux.HandleFunc("/api/runtime/usage-chip", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/api/runtime/usage-chip", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 				handleRuntimeUsageChip(w, r, config, verbose)
-			})
+			}))
 
 			if runningDraftHub != nil {
-				mux.HandleFunc("/api/draft", func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/api/draft", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == http.MethodGet {
 						handleDraftGet(w, r, runningDraftHub)
 						return
@@ -607,14 +608,14 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 						return
 					}
 					w.WriteHeader(http.StatusMethodNotAllowed)
-				})
-				mux.HandleFunc("/api/draft/events", func(w http.ResponseWriter, r *http.Request) {
+				}))
+				mux.HandleFunc("/api/draft/events", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 					handleDraftEvents(w, r, runningDraftHub)
-				})
+				}))
 			}
 
 			// Functional commit handlers that work with the decision channel
-			mux.HandleFunc("/commit", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/commit", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
@@ -626,8 +627,8 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 					}
 				}
 				handleProgressiveDecision(w, decisionflow.DecisionCommit, msg, false)
-			})
-			mux.HandleFunc("/commit-push", func(w http.ResponseWriter, r *http.Request) {
+			}))
+			mux.HandleFunc("/commit-push", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
@@ -639,8 +640,8 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 					}
 				}
 				handleProgressiveDecision(w, decisionflow.DecisionCommit, msg, true)
-			})
-			mux.HandleFunc("/skip", func(w http.ResponseWriter, r *http.Request) {
+			}))
+			mux.HandleFunc("/skip", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
@@ -652,8 +653,8 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 					}
 				}
 				handleProgressiveDecision(w, decisionflow.DecisionSkip, msg, false)
-			})
-			mux.HandleFunc("/vouch", func(w http.ResponseWriter, r *http.Request) {
+			}))
+			mux.HandleFunc("/vouch", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
@@ -665,8 +666,8 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 					}
 				}
 				handleProgressiveDecision(w, decisionflow.DecisionVouch, msg, false)
-			})
-			mux.HandleFunc("/abort", func(w http.ResponseWriter, r *http.Request) {
+			}))
+			mux.HandleFunc("/abort", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
@@ -675,8 +676,8 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 					runningDraftHub.Freeze()
 				}
 				handleProgressiveDecision(w, decisionflow.DecisionAbort, "", false)
-			})
-			mux.HandleFunc("/handoff", func(w http.ResponseWriter, r *http.Request) {
+			}))
+			mux.HandleFunc("/handoff", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
@@ -687,9 +688,9 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 					return
 				}
 				handleProgressiveDecision(w, decisionflow.DecisionHandoff, string(body), false)
-			})
+			}))
 			// Proxy endpoint for review-events API to avoid CORS
-			mux.HandleFunc("/api/v1/diff-review/", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/api/v1/diff-review/", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 				if fakeMode {
 					if r.Method != http.MethodGet {
 						w.WriteHeader(http.StatusMethodNotAllowed)
@@ -718,14 +719,14 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 				}
 
 				handleReviewEventsProxy(w, r, *config, reviewID, verbose)
-			})
+			}))
 			// Proxy feedback endpoints — adds API key so browser never holds the key
-			mux.HandleFunc("/api/v1/feedback", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/api/v1/feedback", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 				handleFeedbackProxy(w, r, *config, verbose)
-			})
-			mux.HandleFunc("/api/v1/feedback/", func(w http.ResponseWriter, r *http.Request) {
+			}))
+			mux.HandleFunc("/api/v1/feedback/", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
 				handleFeedbackProxy(w, r, *config, verbose)
-			})
+			}))
 			server := &http.Server{Handler: mux}
 			if err := server.Serve(serveListener); err != nil && err != http.ErrServerClosed {
 				if verbose {
@@ -1264,7 +1265,7 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 				})
 			} else {
 				// No progressive loading - use normal serveHTMLInteractive
-				code, msg, push, err := serveHTMLInteractive(htmlPath, opts.Port, nonProgressiveListener, initialMsg, reviewMetadata, false, *config)
+				code, msg, push, err := serveHTMLInteractive(htmlPath, opts.Port, nonProgressiveListener, initialMsg, reviewMetadata, false, *config, reviewID)
 				if err != nil {
 					return err
 				}
@@ -2328,6 +2329,21 @@ func writeDraftSnapshot(w http.ResponseWriter, snap draftSnapshot) {
 	}
 }
 
+// requireSession rejects requests whose "r" query param does not match the active reviewID.
+// This prevents a stale browser tab (reused port) from reading or acting on a different review.
+// Fails closed: if sessionID is empty, all requests are rejected.
+func requireSession(sessionID string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		if sessionID == "" || req.URL.Query().Get("r") != sessionID {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"session_mismatch"}`))
+			return
+		}
+		next(w, req)
+	}
+}
+
 func handleDraftGet(w http.ResponseWriter, r *http.Request, hub *draftHub) {
 	if r.Method != http.MethodGet {
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -2586,7 +2602,7 @@ func buildDecisionMetadata(reviewID, account, title, reviewURL string) []string 
 // serveHTMLInteractive serves HTML and waits for user decision
 // Returns decision details (code: 0 commit, 1 abort, 2 skip-from-terminal, 3 skip-from-HTML)
 // skipBrowserOpen: set to true if browser is already open (e.g., from progressive loading)
-func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg string, metadata []string, skipBrowserOpen bool, cfg Config) (int, string, bool, error) {
+func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg string, metadata []string, skipBrowserOpen bool, cfg Config, sessionID string) (int, string, bool, error) {
 	absPath, err := filepath.Abs(htmlPath)
 	if err != nil {
 		return 1, "", false, fmt.Errorf("failed to get absolute path: %w", err)
@@ -2597,7 +2613,7 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 		return 1, "", false, fmt.Errorf("HTML file not found: %w", err)
 	}
 
-	url := fmt.Sprintf("http://localhost:%d", port)
+	url := fmt.Sprintf("http://localhost:%d/?r=%s", port, url.QueryEscape(sessionID))
 	fmt.Printf("\n")
 	fmt.Printf("🌐 Review available at: %s\n", highlightURL(url))
 	fmt.Printf("\n")
@@ -2618,12 +2634,12 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 		http.ServeFile(w, r, absPath)
 	})
 	// Proxy feedback endpoints — adds API key so browser never holds the key
-	mux.HandleFunc("/api/v1/feedback", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/feedback", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
 		handleFeedbackProxy(w, r, cfg, false)
-	})
-	mux.HandleFunc("/api/v1/feedback/", func(w http.ResponseWriter, r *http.Request) {
+	}))
+	mux.HandleFunc("/api/v1/feedback/", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
 		handleFeedbackProxy(w, r, cfg, false)
-	})
+	}))
 
 	type precommitDecision struct {
 		code    int
@@ -2690,7 +2706,7 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 		_, _ = w.Write([]byte("ok"))
 	}
 
-	mux.HandleFunc("/api/draft", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/draft", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			handleDraftGet(w, r, draftState)
 			return
@@ -2700,13 +2716,13 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 			return
 		}
 		w.WriteHeader(http.StatusMethodNotAllowed)
-	})
-	mux.HandleFunc("/api/draft/events", func(w http.ResponseWriter, r *http.Request) {
+	}))
+	mux.HandleFunc("/api/draft/events", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
 		handleDraftEvents(w, r, draftState)
-	})
+	}))
 
 	// Pre-commit action endpoints (HTML buttons call these)
-	mux.HandleFunc("/commit", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/commit", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
@@ -2716,9 +2732,9 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 			msg = snap.Text
 		}
 		handleDecision(w, decisionflow.DecisionCommit, msg, false)
-	})
+	}))
 
-	mux.HandleFunc("/commit-push", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/commit-push", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
@@ -2728,9 +2744,9 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 			msg = snap.Text
 		}
 		handleDecision(w, decisionflow.DecisionCommit, msg, true)
-	})
+	}))
 
-	mux.HandleFunc("/skip", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/skip", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
@@ -2740,9 +2756,9 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 			msg = snap.Text
 		}
 		handleDecision(w, decisionflow.DecisionSkip, msg, false)
-	})
+	}))
 
-	mux.HandleFunc("/vouch", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/vouch", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
@@ -2752,18 +2768,18 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 			msg = snap.Text
 		}
 		handleDecision(w, decisionflow.DecisionVouch, msg, false)
-	})
+	}))
 
-	mux.HandleFunc("/abort", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/abort", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
 		draftState.Freeze()
 		handleDecision(w, decisionflow.DecisionAbort, "", false)
-	})
+	}))
 
-	mux.HandleFunc("/handoff", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/handoff", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
@@ -2774,7 +2790,7 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 			return
 		}
 		handleDecision(w, decisionflow.DecisionHandoff, string(body), false)
-	})
+	}))
 
 	// Start server in background using the already-open listener
 	server := &http.Server{

--- a/internal/appcore/review_runtime.go
+++ b/internal/appcore/review_runtime.go
@@ -483,6 +483,7 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 		}
 
 		serveURL := fmt.Sprintf("http://localhost:%d/?r=%s", opts.Port, url.QueryEscape(reviewID))
+		reviewMetadata = append(reviewMetadata, fmt.Sprintf("Local review: %s", serveURL))
 		if !useInteractive {
 			fmt.Printf("\n🌐 Review available at: %s\n", highlightURL(serveURL))
 			fmt.Printf("   Comments will appear progressively as review runs\n\n")

--- a/internal/appcore/review_runtime.go
+++ b/internal/appcore/review_runtime.go
@@ -726,10 +726,10 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 			}))
 			// Proxy feedback endpoints — adds API key so browser never holds the key
 			mux.HandleFunc("/api/v1/feedback", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
-				handleFeedbackProxy(w, r, *config, verbose)
+				handleFeedbackProxy(w, r, *config, verbose, reviewID)
 			}))
 			mux.HandleFunc("/api/v1/feedback/", requireSession(reviewID, func(w http.ResponseWriter, r *http.Request) {
-				handleFeedbackProxy(w, r, *config, verbose)
+				handleFeedbackProxy(w, r, *config, verbose, reviewID)
 			}))
 			server := &http.Server{Handler: mux}
 			if err := server.Serve(serveListener); err != nil && err != http.ErrServerClosed {
@@ -2541,7 +2541,7 @@ func handleReviewEventsProxy(w http.ResponseWriter, r *http.Request, config Conf
 	}
 }
 
-func handleFeedbackProxy(w http.ResponseWriter, r *http.Request, config Config, verbose bool) {
+func handleFeedbackProxy(w http.ResponseWriter, r *http.Request, config Config, verbose bool, reviewID string) {
 	var reqBody []byte
 	if r.Body != nil {
 		const maxProxyBodyBytes = 8 << 20
@@ -2555,6 +2555,21 @@ func handleFeedbackProxy(w http.ResponseWriter, r *http.Request, config Config, 
 			return
 		}
 		reqBody = readBody
+	}
+
+	// Inject review_id from the server-side session so the DB row is always linked
+	if reviewID != "" {
+		if rid, err := strconv.ParseInt(reviewID, 10, 64); err == nil {
+			var payload map[string]interface{}
+			if json.Unmarshal(reqBody, &payload) == nil {
+				if _, already := payload["review_id"]; !already {
+					payload["review_id"] = rid
+					if merged, mergeErr := json.Marshal(payload); mergeErr == nil {
+						reqBody = merged
+					}
+				}
+			}
+		}
 	}
 
 	headers := map[string]string{"X-API-Key": config.APIKey}
@@ -2639,10 +2654,10 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 	})
 	// Proxy feedback endpoints — adds API key so browser never holds the key
 	mux.HandleFunc("/api/v1/feedback", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
-		handleFeedbackProxy(w, r, cfg, false)
+		handleFeedbackProxy(w, r, cfg, false, sessionID)
 	}))
 	mux.HandleFunc("/api/v1/feedback/", requireSession(sessionID, func(w http.ResponseWriter, r *http.Request) {
-		handleFeedbackProxy(w, r, cfg, false)
+		handleFeedbackProxy(w, r, cfg, false, sessionID)
 	}))
 
 	type precommitDecision struct {

--- a/internal/appcore/review_runtime.go
+++ b/internal/appcore/review_runtime.go
@@ -492,6 +492,9 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 			fmt.Printf("   Comments will appear progressively as review runs\n\n")
 		}
 
+		unregister := registerActiveReview(opts.Port, reviewID, submitResp.FriendlyName, repoName, time.Now())
+		defer unregister()
+
 		// Auto-open the review in the default browser
 		openURL(serveURL)
 
@@ -571,6 +574,10 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != "/" {
 					http.NotFound(w, r)
+					return
+				}
+				if r.URL.Query().Get("r") == "" {
+					serveReviewListing(w, *config)
 					return
 				}
 				w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -1269,7 +1276,7 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 				})
 			} else {
 				// No progressive loading - use normal serveHTMLInteractive
-				code, msg, push, err := serveHTMLInteractive(htmlPath, opts.Port, nonProgressiveListener, initialMsg, reviewMetadata, false, *config, reviewID)
+				code, msg, push, err := serveHTMLInteractive(htmlPath, opts.Port, nonProgressiveListener, initialMsg, reviewMetadata, false, *config, reviewID, submitResp.FriendlyName, repoName)
 				if err != nil {
 					return err
 				}
@@ -2601,6 +2608,7 @@ func handleFeedbackProxy(w http.ResponseWriter, r *http.Request, config Config, 
 	}
 }
 
+
 func buildDecisionMetadata(reviewID, account, title, reviewURL string) []string {
 	metadata := make([]string, 0, 4)
 	if strings.TrimSpace(reviewID) != "" {
@@ -2621,7 +2629,7 @@ func buildDecisionMetadata(reviewID, account, title, reviewURL string) []string 
 // serveHTMLInteractive serves HTML and waits for user decision
 // Returns decision details (code: 0 commit, 1 abort, 2 skip-from-terminal, 3 skip-from-HTML)
 // skipBrowserOpen: set to true if browser is already open (e.g., from progressive loading)
-func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg string, metadata []string, skipBrowserOpen bool, cfg Config, sessionID string) (int, string, bool, error) {
+func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg string, metadata []string, skipBrowserOpen bool, cfg Config, sessionID, friendlyName, repository string) (int, string, bool, error) {
 	absPath, err := filepath.Abs(htmlPath)
 	if err != nil {
 		return 1, "", false, fmt.Errorf("failed to get absolute path: %w", err)
@@ -2637,6 +2645,9 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 	fmt.Printf("🌐 Review available at: %s\n", highlightURL(url))
 	fmt.Printf("\n")
 
+	unregister := registerActiveReview(port, sessionID, friendlyName, repository, time.Now())
+	defer unregister()
+
 	// Open browser only if not already open
 	if !skipBrowserOpen {
 		go func() {
@@ -2650,6 +2661,10 @@ func serveHTMLInteractive(htmlPath string, port int, ln net.Listener, initialMsg
 	// Serve static assets (JS, CSS) from embedded filesystem
 	mux.Handle("/static/", http.StripPrefix("/static/", staticserve.GetStaticHandler()))
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" && r.URL.Query().Get("r") == "" {
+			serveReviewListing(w, cfg)
+			return
+		}
 		http.ServeFile(w, r, absPath)
 	})
 	// Proxy feedback endpoints — adds API key so browser never holds the key

--- a/internal/appcore/review_runtime_landing.go
+++ b/internal/appcore/review_runtime_landing.go
@@ -1,0 +1,438 @@
+package appcore
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type githubRepoStats struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Stars       int    `json:"stargazers_count"`
+	Forks       int    `json:"forks_count"`
+	Watchers    int    `json:"subscribers_count"`
+	OpenIssues  int    `json:"open_issues_count"`
+	Language    string `json:"language"`
+	HTMLURL     string `json:"html_url"`
+}
+
+func fetchGitHubStats() *githubRepoStats {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get("https://api.github.com/repos/HexmosTech/git-lrc")
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	var stats githubRepoStats
+	if json.NewDecoder(resp.Body).Decode(&stats) != nil {
+		return nil
+	}
+	return &stats
+}
+
+type reviewRegistryEntry struct {
+	ReviewID     string    `json:"review_id"`
+	FriendlyName string    `json:"friendly_name"`
+	Repository   string    `json:"repository"`
+	Port         int       `json:"port"`
+	PID          int       `json:"pid"`
+	StartedAt    time.Time `json:"started_at"`
+}
+
+func reviewRegistryDir() string {
+	return filepath.Join(os.TempDir(), ".lrc-reviews")
+}
+
+// registerActiveReview writes a registry entry to /tmp/.lrc-reviews/<port>.json so the
+// listing page can discover live review processes across ports. Returns a cleanup func that
+// removes the file on exit. On any write failure the review still works; listing just won't
+// show this entry.
+func registerActiveReview(port int, reviewID, friendlyName, repository string, startedAt time.Time) func() {
+	dir := reviewRegistryDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return func() {}
+	}
+	entry := reviewRegistryEntry{
+		ReviewID:     reviewID,
+		FriendlyName: friendlyName,
+		Repository:   repository,
+		Port:         port,
+		PID:          os.Getpid(),
+		StartedAt:    startedAt,
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return func() {}
+	}
+	path := filepath.Join(dir, fmt.Sprintf("%d.json", port))
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return func() {}
+	}
+	return func() { _ = os.Remove(path) }
+}
+
+// readActiveReviews scans /tmp/.lrc-reviews/ and returns entries for live processes.
+// PID liveness is checked via kill(pid, 0) — Unix-only; stale files are cleaned up.
+// All errors are treated as "skip this entry" — the listing is best-effort.
+func readActiveReviews() []reviewRegistryEntry {
+	dir := reviewRegistryDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var result []reviewRegistryEntry
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var entry reviewRegistryEntry
+		if json.Unmarshal(data, &entry) != nil {
+			continue
+		}
+		if !isProcessAlive(entry.PID) {
+			_ = os.Remove(filepath.Join(dir, e.Name()))
+			continue
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+type listingImpactStats struct {
+	TotalReviews int `json:"total_reviews"`
+	IssuesFound  int `json:"issues_found"`
+	BugsCaught   int `json:"bugs_caught"`
+	Critical     int `json:"critical"`
+	Errors       int `json:"errors"`
+	Warnings     int `json:"warnings"`
+	Info         int `json:"info"`
+}
+
+func fetchListingImpactStats(apiURL, apiKey string) *listingImpactStats {
+	client := &http.Client{Timeout: 3 * time.Second}
+	req, err := http.NewRequest("GET", strings.TrimRight(apiURL, "/")+"/api/v1/feedback/impact-stats", nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("X-API-Key", apiKey)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	var stats listingImpactStats
+	if json.NewDecoder(resp.Body).Decode(&stats) != nil {
+		return nil
+	}
+	return &stats
+}
+
+// serveReviewListing renders the VS Code-styled active-reviews page at GET /.
+// It is called from two mutually exclusive code paths:
+//   - progressive review path (inside runReviewWithOptions HTTP server)
+//   - non-progressive path (inside serveHTMLInteractive HTTP server)
+//
+// Both paths have already called registerActiveReview for their own process, so there is
+// no double-registration: these code paths never run in the same process simultaneously.
+func serveReviewListing(w http.ResponseWriter, cfg Config) {
+	// Fetch GitHub stats and impact stats concurrently to cap latency at 3s, not 6s.
+	var ghStats *githubRepoStats
+	var impact *listingImpactStats
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); ghStats = fetchGitHubStats() }()
+	go func() { defer wg.Done(); impact = fetchListingImpactStats(cfg.APIURL, cfg.APIKey) }()
+	wg.Wait()
+
+	reviews := readActiveReviews()
+
+	iv := func(n int) string { return fmt.Sprintf("%d", n) }
+	totalReviews, issuesFound, bugsCaught, critical, errsCount, warnings := "—", "—", "—", "—", "—", "—"
+	if impact != nil {
+		totalReviews = iv(impact.TotalReviews)
+		issuesFound = iv(impact.IssuesFound)
+		bugsCaught = iv(impact.BugsCaught)
+		critical = iv(impact.Critical)
+		errsCount = iv(impact.Errors)
+		warnings = iv(impact.Warnings)
+	}
+
+	shareText := fmt.Sprintf(`🚀 Shipping with confidence — here's my code review impact since Jan 2025:
+
+✅ %s reviews completed
+🐛 %s bugs caught before production
+🔍 %s total issues found
+🔴 %s critical issues found
+🟠 %s errors caught
+🟡 %s warnings flagged
+
+Using git-lrc to AI-review every commit before it lands.
+
+⭐ Star it if you find it useful: https://github.com/HexmosTech/git-lrc
+
+#CodeReview #DevOps #SoftwareEngineering #AI`, totalReviews, bugsCaught, issuesFound, critical, errsCount, warnings)
+
+	statsRows := fmt.Sprintf(`
+<div class="stat-row"><span class="stat-label">Reviews completed</span><span class="stat-val">%s</span></div>
+<div class="stat-row"><span class="stat-label">Issues found</span><span class="stat-val">%s</span></div>
+<div class="stat-row"><span class="stat-label">Bugs caught pre-prod</span><span class="stat-val">%s</span></div>
+<div class="stat-row"><span class="stat-label">Critical</span><span class="stat-val">%s</span></div>
+<div class="stat-row"><span class="stat-label">Errors</span><span class="stat-val">%s</span></div>
+<div class="stat-row"><span class="stat-label">Warnings</span><span class="stat-val">%s</span></div>`,
+		totalReviews, issuesFound, bugsCaught, critical, errsCount, warnings)
+
+	tableRows := ""
+	if len(reviews) == 0 {
+		tableRows = `<tr><td colspan="5" style="text-align:center;padding:32px 0;color:#6a6a6a;font-style:italic;">No active reviews</td></tr>`
+	} else {
+		for _, rv := range reviews {
+			name := html.EscapeString(rv.FriendlyName)
+			if name == "" {
+				name = "Review #" + html.EscapeString(rv.ReviewID)
+			}
+			repo := html.EscapeString(rv.Repository)
+			if repo == "" {
+				repo = "—"
+			}
+			elapsed := "—"
+			if !rv.StartedAt.IsZero() {
+				d := time.Since(rv.StartedAt)
+				if d < time.Minute {
+					elapsed = fmt.Sprintf("%.0fs ago", d.Seconds())
+				} else {
+					elapsed = fmt.Sprintf("%.0fm ago", d.Minutes())
+				}
+			}
+			href := fmt.Sprintf("http://localhost:%d/?r=%s", rv.Port, url.QueryEscape(rv.ReviewID))
+			// html.EscapeString is applied to href in both the onclick JS string and the href
+			// attribute so that any character that could break out of the attribute is neutralised.
+			safeHref := html.EscapeString(href)
+			tableRows += fmt.Sprintf(`
+<tr class="trow" onclick="location.href='%s'">
+  <td class="td-name">
+    <svg class="td-icon" width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="#569cd6" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
+    <a href="%s" class="name-link">%s</a>
+  </td>
+  <td class="td-repo">%s</td>
+  <td class="td-id">%s</td>
+  <td class="td-port">%d</td>
+  <td class="td-started">%s</td>
+</tr>`, safeHref, safeHref, name, repo, html.EscapeString(rv.ReviewID), rv.Port, elapsed)
+		}
+	}
+
+	const ghFallbackPanel = `
+<div class="gh-name">
+  <svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24" style="flex-shrink:0;color:#cccccc;"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+  <a href="https://github.com/HexmosTech/git-lrc" target="_blank" class="gh-link">git-lrc</a>
+</div>
+<p class="gh-desc">AI-powered code review in your git commit flow.</p>
+<div class="gh-stats">
+  <div class="gh-stat"><span class="gh-stat-icon">★</span><span class="gh-stat-val">1048+</span><span class="gh-stat-lbl">stars</span></div>
+  <div class="gh-stat"><span class="gh-stat-icon">⑂</span><span class="gh-stat-val">157+</span><span class="gh-stat-lbl">forks</span></div>
+  <div class="gh-stat"><span class="gh-stat-icon">◎</span><span class="gh-stat-val">20+</span><span class="gh-stat-lbl">issues</span></div>
+</div>
+<div class="gh-lang"><span class="lang-dot"></span>Go</div>
+<a href="https://github.com/HexmosTech/git-lrc" target="_blank" class="star-btn">
+  <svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+  Star on GitHub
+</a>`
+
+	ghPanel := ghFallbackPanel
+	if ghStats != nil {
+		desc := ghStats.Description
+		if desc == "" {
+			desc = "AI-powered code review in your git commit flow."
+		}
+		ghPanel = fmt.Sprintf(`
+<div class="gh-name">
+  <svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24" style="flex-shrink:0;color:#cccccc;"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+  <a href="%s" target="_blank" class="gh-link">%s</a>
+</div>
+<p class="gh-desc">%s</p>
+<div class="gh-stats">
+  <div class="gh-stat"><span class="gh-stat-icon">★</span><span class="gh-stat-val">%d</span><span class="gh-stat-lbl">stars</span></div>
+  <div class="gh-stat"><span class="gh-stat-icon">⑂</span><span class="gh-stat-val">%d</span><span class="gh-stat-lbl">forks</span></div>
+  <div class="gh-stat"><span class="gh-stat-icon">◎</span><span class="gh-stat-val">%d</span><span class="gh-stat-lbl">issues</span></div>
+</div>
+<div class="gh-lang"><span class="lang-dot"></span>%s</div>
+<a href="%s" target="_blank" class="star-btn">
+  <svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+  Star on GitHub
+</a>`,
+			html.EscapeString(ghStats.HTMLURL), html.EscapeString(ghStats.Name),
+			html.EscapeString(desc),
+			ghStats.Stars, ghStats.Forks, ghStats.OpenIssues,
+			html.EscapeString(ghStats.Language),
+			html.EscapeString(ghStats.HTMLURL))
+	}
+
+	page := fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>LiveReview — Active Reviews</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{background:#1e1e1e;color:#cccccc;font-family:"Segoe UI",system-ui,-apple-system,sans-serif;font-size:13px;min-height:100vh;}
+.titlebar{background:#323233;border-bottom:1px solid #111;height:35px;display:flex;align-items:center;padding:0 14px;gap:8px;user-select:none;position:fixed;top:0;left:0;right:0;z-index:10;}
+.titlebar-dot{color:#555;}.titlebar-text{color:#cccccc;font-size:12px;}
+.activity{position:fixed;top:35px;left:0;bottom:22px;width:48px;background:#333333;border-right:1px solid #252526;display:flex;flex-direction:column;align-items:center;padding-top:6px;gap:2px;z-index:9;}
+.act-btn{width:40px;height:40px;display:flex;align-items:center;justify-content:center;color:#858585;cursor:pointer;border:none;background:none;border-radius:4px;}
+.act-btn:hover{color:#cccccc;}
+.act-btn.open{color:#cccccc;box-shadow:inset 2px 0 0 #569cd6;}
+.side-panel{position:fixed;top:35px;left:48px;bottom:22px;width:280px;background:#252526;border-right:1px solid #1a1a1a;display:none;flex-direction:column;z-index:8;overflow:hidden;}
+.side-panel.visible{display:flex;}
+.panel-hdr{padding:9px 12px 8px;font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#bbbbbb;border-bottom:1px solid #1a1a1a;flex-shrink:0;}
+.panel-body{padding:12px;flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:10px;}
+.stat-row{display:flex;justify-content:space-between;align-items:baseline;padding:4px 0;border-bottom:1px solid #2d2d2d;}
+.stat-row:last-child{border-bottom:none;}
+.stat-label{color:#9a9a9a;font-size:12px;}.stat-val{color:#9cdcfe;font-size:12px;font-family:monospace;font-weight:600;}
+.share-textarea{width:100%%;height:200px;background:#1e1e1e;border:1px solid #3c3c3c;border-radius:3px;color:#cccccc;font-size:11px;font-family:"Segoe UI",system-ui,sans-serif;line-height:1.6;padding:10px;resize:vertical;outline:none;}
+.share-textarea:focus{border-color:#569cd6;}
+.copy-btn{width:100%%;padding:6px 0;background:#0e639c;border:none;border-radius:3px;color:#fff;font-size:12px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:6px;transition:background .15s;flex-shrink:0;}
+.copy-btn:hover{background:#1177bb;}.copy-btn.copied{background:#16825d;}.copy-btn.failed{background:#c62828;}
+.gh-name{display:flex;align-items:center;gap:7px;}
+.gh-link{color:#9cdcfe;text-decoration:none;font-size:13px;font-weight:600;}.gh-link:hover{text-decoration:underline;}
+.gh-desc{color:#9a9a9a;font-size:11px;line-height:1.5;}
+.gh-stats{display:flex;gap:14px;}
+.gh-stat{display:flex;align-items:center;gap:4px;}
+.gh-stat-icon{font-size:13px;color:#e3b341;}
+.gh-stat-val{color:#cccccc;font-size:12px;font-weight:600;}
+.gh-stat-lbl{color:#6a6a6a;font-size:11px;}
+.gh-lang{display:flex;align-items:center;gap:5px;color:#9a9a9a;font-size:11px;}
+.lang-dot{width:10px;height:10px;border-radius:50%%;background:#00add8;flex-shrink:0;}
+.star-btn{display:flex;align-items:center;justify-content:center;gap:6px;padding:7px 0;background:#238636;border:none;border-radius:3px;color:#fff;font-size:12px;cursor:pointer;text-decoration:none;transition:background .15s;width:100%%;}
+.star-btn:hover{background:#2ea043;}
+.gh-cta{color:#9a9a9a;font-size:12px;line-height:1.6;}
+.gh-cta a{color:#569cd6;text-decoration:none;}.gh-cta a:hover{text-decoration:underline;}
+.main{margin-left:48px;margin-top:35px;padding:24px 28px;overflow-y:auto;height:calc(100vh - 57px);transition:margin-left .15s;}
+.main.shifted{margin-left:328px;}
+.sec-hdr{font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#bbbbbb;margin-bottom:12px;display:flex;align-items:center;gap:7px;}
+.badge{background:#0e639c;color:#fff;font-size:10px;font-weight:700;padding:1px 7px;border-radius:10px;letter-spacing:0;text-transform:none;}
+table{width:100%%;border-collapse:collapse;}
+thead tr{border-bottom:1px solid #3c3c3c;}
+th{text-align:left;font-size:11px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:#858585;padding:0 12px 8px;}
+th:first-child{padding-left:4px;}
+.trow{cursor:pointer;border-bottom:1px solid #2a2a2a;transition:background .1s;}
+.trow:hover{background:#2a2d2e;}.trow:last-child{border-bottom:none;}
+td{padding:10px 12px;vertical-align:middle;}td:first-child{padding-left:4px;}
+.td-name{display:flex;align-items:center;gap:7px;white-space:nowrap;}
+.name-link{color:#9cdcfe;text-decoration:none;font-size:13px;}.name-link:hover{text-decoration:underline;}
+.td-repo{color:#ce9178;font-size:12px;white-space:nowrap;}
+.td-id,.td-port,.td-started{color:#9a9a9a;font-size:12px;white-space:nowrap;}
+.statusbar{position:fixed;bottom:0;left:0;right:0;height:22px;background:#007acc;display:flex;align-items:center;padding:0 10px;gap:14px;font-size:11px;color:#fff;}
+</style>
+</head>
+<body>
+<div class="titlebar">
+  <svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="#569cd6" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
+  <span class="titlebar-text">LiveReview</span>
+  <span class="titlebar-dot">—</span>
+  <span class="titlebar-text">Active Reviews</span>
+</div>
+<div class="activity">
+  <button class="act-btn" id="statsBtn" title="Impact stats" onclick="toggle('stats')">
+    <svg width="17" height="17" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+  </button>
+  <button class="act-btn" id="shareBtn" title="Share impact" onclick="toggle('share')">
+    <svg width="17" height="17" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+  </button>
+  <button class="act-btn" id="infoBtn" title="About git-lrc" onclick="toggle('info')">
+    <svg width="17" height="17" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="8" stroke-linecap="round" stroke-width="2.5"/><line x1="12" y1="12" x2="12" y2="16" stroke-linecap="round"/></svg>
+  </button>
+</div>
+
+<div class="side-panel" id="statsPanel">
+  <div class="panel-hdr">Impact Stats</div>
+  <div class="panel-body">%s</div>
+</div>
+
+<div class="side-panel" id="sharePanel">
+  <div class="panel-hdr">Share Impact</div>
+  <div class="panel-body">
+    <textarea class="share-textarea" id="shareText">%s</textarea>
+    <button class="copy-btn" id="copyBtn" onclick="copyShare()">
+      <svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+      Copy message
+    </button>
+  </div>
+</div>
+
+<div class="side-panel" id="infoPanel">
+  <div class="panel-hdr">About git-lrc</div>
+  <div class="panel-body">
+    <p class="gh-cta">Is it being useful? If you haven't starred, <a href="https://github.com/HexmosTech/git-lrc" target="_blank">star us on GitHub</a> — it really helps!</p>
+    %s
+  </div>
+</div>
+
+<div class="main" id="main">
+  <div class="sec-hdr">Active <span class="badge">%d</span></div>
+  <table>
+    <thead><tr><th>Name</th><th>Repository</th><th>ID</th><th>Port</th><th>Started</th></tr></thead>
+    <tbody>%s</tbody>
+  </table>
+</div>
+<div class="statusbar"><a href="https://hexmos.com/livereview/" target="_blank" style="color:#fff;text-decoration:none;">LiveReview</a><span>git-lrc</span></div>
+<script>
+const COPY_SVG = '<svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg> Copy message';
+let openPanel = null;
+const PANELS = ['stats','share','info'];
+function toggle(which) {
+  const main = document.getElementById('main');
+  if (openPanel === which) {
+    document.getElementById(which+'Panel').classList.remove('visible');
+    document.getElementById(which+'Btn').classList.remove('open');
+    main.classList.remove('shifted');
+    openPanel = null;
+    return;
+  }
+  PANELS.forEach(p => {
+    document.getElementById(p+'Panel').classList.remove('visible');
+    document.getElementById(p+'Btn').classList.remove('open');
+  });
+  document.getElementById(which+'Panel').classList.add('visible');
+  document.getElementById(which+'Btn').classList.add('open');
+  main.classList.add('shifted');
+  openPanel = which;
+}
+function copyShare() {
+  const btn = document.getElementById('copyBtn');
+  const text = document.getElementById('shareText').value;
+  navigator.clipboard.writeText(text).then(() => {
+    btn.classList.add('copied');
+    btn.innerHTML = '<svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg> Copied!';
+    setTimeout(() => {
+      btn.classList.remove('copied');
+      btn.innerHTML = COPY_SVG;
+    }, 2000);
+  }).catch(() => {
+    btn.classList.add('failed');
+    btn.textContent = 'Copy failed — select text manually';
+    setTimeout(() => {
+      btn.classList.remove('failed');
+      btn.innerHTML = COPY_SVG;
+    }, 2500);
+  });
+}
+</script>
+</body>
+</html>`, statsRows, shareText, ghPanel, len(reviews), tableRows)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, page)
+}

--- a/internal/appcore/review_runtime_pid_unix.go
+++ b/internal/appcore/review_runtime_pid_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package appcore
+
+import (
+	"os"
+	"syscall"
+)
+
+// isProcessAlive checks if a process is still running via kill(pid, 0).
+func isProcessAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/internal/appcore/review_runtime_pid_windows.go
+++ b/internal/appcore/review_runtime_pid_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package appcore
+
+import "os"
+
+// isProcessAlive on Windows uses os.FindProcess which opens a process handle via
+// OpenProcess. An error means the PID does not exist. Note: PID reuse is possible
+// but rare in practice for a local listing that refreshes on every page load.
+func isProcessAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	proc.Release()
+	return true
+}

--- a/internal/staticserve/static/app.js
+++ b/internal/staticserve/static/app.js
@@ -281,6 +281,8 @@ async function initApp() {
         const reviewStartMsRef = useRef(domReadyStartMs || getPerformanceNow());
         const reviewCompletedMsRef = useRef(null);
         const [logsCopied, setLogsCopied] = useState(false);
+        const [sessionEnded, setSessionEnded] = useState(false);
+        const sessionReviewID = new URLSearchParams(window.location.search).get('r') || '';
 
         useEffect(() => {
             activeTabRef.current = activeTab;
@@ -296,7 +298,13 @@ async function initApp() {
         // Fetch review data from API
         const fetchInitialReviewData = useCallback(async () => {
             try {
-                const response = await fetch('/api/review');
+                const url = sessionReviewID ? `/api/review?r=${sessionReviewID}` : '/api/review';
+                const response = await fetch(url);
+                if (response.status === 403) {
+                    setSessionEnded(true);
+                    setLoading(false);
+                    return null;
+                }
                 if (!response.ok) {
                     throw new Error(`Failed to fetch review data: ${response.status}`);
                 }
@@ -311,14 +319,15 @@ async function initApp() {
                 setLoading(false);
                 return null;
             }
-        }, [commitReviewData]);
+        }, [commitReviewData, sessionReviewID]);
 
         const fetchFinalReviewData = useCallback(async (reviewID) => {
             if (!reviewID) return null;
 
+            const rParam = sessionReviewID ? `?r=${sessionReviewID}` : '';
             const fetchTargets = [
-                `/api/v1/diff-review/${reviewID}`,
-                '/api/review'
+                `/api/v1/diff-review/${reviewID}${rParam}`,
+                `/api/review${rParam}`
             ];
 
             for (const url of fetchTargets) {
@@ -345,7 +354,7 @@ async function initApp() {
             }
 
             return null;
-        }, [commitReviewData]);
+        }, [commitReviewData, sessionReviewID]);
         
         // Fetch events for live logs and comments
         const fetchEvents = useCallback(async (reviewID) => {
@@ -354,7 +363,13 @@ async function initApp() {
             eventsInFlightRef.current = true;
             
             try {
-                const response = await fetch(buildEventsURL(reviewID, lastSeenEventTimeRef.current));
+                const baseEventsURL = buildEventsURL(reviewID, lastSeenEventTimeRef.current);
+                const eventsURL = sessionReviewID ? `${baseEventsURL}&r=${sessionReviewID}` : baseEventsURL;
+                const response = await fetch(eventsURL);
+                if (response.status === 403) {
+                    setSessionEnded(true);
+                    return;
+                }
                 if (!response.ok) return;
                 
                 const data = await response.json();
@@ -412,7 +427,7 @@ async function initApp() {
             } finally {
                 eventsInFlightRef.current = false;
             }
-        }, [commitReviewData, fetchFinalReviewData]);
+        }, [commitReviewData, fetchFinalReviewData, sessionReviewID]);
         
         // Initial load and polling setup
         useEffect(() => {
@@ -678,7 +693,8 @@ async function initApp() {
             };
             
             try {
-                const response = await fetch('/handoff', {
+                const handoffURL = sessionReviewID ? `/handoff?r=${sessionReviewID}` : '/handoff';
+                const response = await fetch(handoffURL, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(payload)
@@ -803,6 +819,25 @@ async function initApp() {
             }
         }, [events]);
         
+        // Session mismatch — stale tab refreshed on a reused port
+        if (sessionEnded) {
+            return html`
+                <div class="loading-screen">
+                    <div class="loading-content">
+                        <div class="loading-logo error">
+                            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                                <circle cx="12" cy="12" r="10" />
+                                <path d="M12 8v4M12 16h.01" stroke-linecap="round" />
+                            </svg>
+                        </div>
+                        <h1 class="loading-title">Session Ended</h1>
+                        <p class="loading-text">This review session is no longer active.</p>
+                        <p class="loading-text" style="font-size:13px;opacity:0.7">Close this tab and open the new review from your terminal.</p>
+                    </div>
+                </div>
+            `;
+        }
+
         // Loading state
         if (loading && !reviewData) {
             return html`

--- a/internal/staticserve/static/app.js
+++ b/internal/staticserve/static/app.js
@@ -323,37 +323,19 @@ async function initApp() {
 
         const fetchFinalReviewData = useCallback(async (reviewID) => {
             if (!reviewID) return null;
-
             const rParam = sessionReviewID ? `?r=${sessionReviewID}` : '';
-            const fetchTargets = [
-                `/api/v1/diff-review/${reviewID}${rParam}`,
-                `/api/review${rParam}`
-            ];
-
-            for (const url of fetchTargets) {
-                try {
-                    const response = await fetch(url);
-                    if (!response.ok) {
-                        continue;
-                    }
-                    const data = await response.json();
-                    commitReviewData(prev => {
-                        if (!prev) {
-                            return data;
-                        }
-                        return {
-                            ...prev,
-                            ...data,
-                            files: data.files || prev.files || []
-                        };
-                    });
-                    return data;
-                } catch (err) {
-                    console.error(`Error fetching final review data from ${url}:`, err);
-                }
+            try {
+                const response = await fetch(`/api/v1/diff-review/${reviewID}${rParam}`);
+                if (!response.ok) return null;
+                const data = await response.json();
+                commitReviewData(prev =>
+                    prev ? { ...prev, ...data, files: data.files || prev.files || [] } : data
+                );
+                return data;
+            } catch (err) {
+                console.error('Error fetching final review data:', err);
+                return null;
             }
-
-            return null;
         }, [commitReviewData, sessionReviewID]);
         
         // Fetch events for live logs and comments

--- a/internal/staticserve/static/components/FeedbackPopup.js
+++ b/internal/staticserve/static/components/FeedbackPopup.js
@@ -2,6 +2,8 @@
 import { waitForPreact, copyToClipboard } from "./utils.js";
 import { getReviewMeta } from "./reviewMeta.mjs";
 
+const SESSION_REVIEW_ID = new URLSearchParams(window.location.search).get('r') || '';
+
 // module-level cache — fetched once per session
 let _impactStats = null;
 let _impactStatsFetching = false;
@@ -18,7 +20,10 @@ function retractStoredFeedback(key) {
   const id = _feedbackIds[key];
   if (!id) return;
   delete _feedbackIds[key];
-  fetch(`/api/v1/feedback/${id}/retract`, { method: "PATCH" }).catch(() => {});
+  const retractURL = SESSION_REVIEW_ID
+    ? `/api/v1/feedback/${id}/retract?r=${SESSION_REVIEW_ID}`
+    : `/api/v1/feedback/${id}/retract`;
+  fetch(retractURL, { method: "PATCH" }).catch(() => {});
 }
 
 export function fetchImpactStats(reviewID, onReady) {
@@ -29,9 +34,10 @@ export function fetchImpactStats(reviewID, onReady) {
   _impactStatsCallbacks.push(onReady);
   if (_impactStatsFetching) return;
   _impactStatsFetching = true;
-  const url = reviewID
-    ? `/api/v1/feedback/impact-stats?review_id=${reviewID}`
-    : `/api/v1/feedback/impact-stats`;
+  const statsParams = new URLSearchParams();
+  if (reviewID) statsParams.set('review_id', reviewID);
+  if (SESSION_REVIEW_ID) statsParams.set('r', SESSION_REVIEW_ID);
+  const url = `/api/v1/feedback/impact-stats${statsParams.toString() ? '?' + statsParams.toString() : ''}`;
   fetch(url)
     .then((r) => r.json())
     .then((data) => {
@@ -269,7 +275,8 @@ export async function createFeedbackPopup() {
         if (filePath) body.file_path = filePath;
         if (severity) body.severity = severity;
         Object.assign(body, extra);
-        fetch("/api/v1/feedback", {
+        const feedbackURL = SESSION_REVIEW_ID ? `/api/v1/feedback?r=${SESSION_REVIEW_ID}` : '/api/v1/feedback';
+        fetch(feedbackURL, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
@@ -366,7 +373,8 @@ export async function createFeedbackPopup() {
           ...(feedbackText && { feedback_text: feedbackText }),
           ...(codeExcerpt && { code_excerpt: codeExcerpt }),
         };
-        const res = await fetch("/api/v1/feedback", {
+        const feedbackPostURL = SESSION_REVIEW_ID ? `/api/v1/feedback?r=${SESSION_REVIEW_ID}` : '/api/v1/feedback';
+        const res = await fetch(feedbackPostURL, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),

--- a/internal/staticserve/static/components/Header.js
+++ b/internal/staticserve/static/components/Header.js
@@ -4,6 +4,8 @@ import { UsageChip } from '/static/components/UsageChip.js';
 import { fetchImpactStats, buildLinkedinText } from '/static/components/FeedbackPopup.js';
 import { getReviewMeta } from '/static/components/reviewMeta.mjs';
 
+const SESSION_REVIEW_ID = new URLSearchParams(window.location.search).get('r') || '';
+
 const GITHUB_URL = 'https://github.com/HexmosTech/git-lrc';
 const LIVEREVIEW_URL = 'https://hexmos.com/livereview/';
 
@@ -99,7 +101,7 @@ export async function createHeader() {
 
     // ── brand text click popup ────────────────────────────────────────────────
 
-    function BrandButton() {
+    function BrandButton({ friendlyName, generatedTime }) {
         const { isOpen, open, closeSoon } = useHoverPopover();
         const [copied, setCopied] = useState(false);
         const copyTimer = useRef(null);
@@ -116,8 +118,15 @@ export async function createHeader() {
         };
 
         return html`
-            <div style="position:relative;" onMouseEnter=${open} onMouseLeave=${closeSoon}>
-                <h1 style="cursor:default;" title="Share LiveReview">LiveReview Results</h1>
+            <div style="position:relative;">
+                <h1 style="cursor:default;" title="Share LiveReview" onMouseEnter=${open} onMouseLeave=${closeSoon}>LiveReview Results</h1>
+                ${(friendlyName || generatedTime) && html`
+                    <div style="display:flex;align-items:center;gap:8px;margin-top:1px;">
+                        ${friendlyName && html`<span style="color:#c9d5e8;font-size:11px;font-weight:600;">Run: ${friendlyName}</span>`}
+                        ${friendlyName && generatedTime && html`<span style="color:#3a4a60;font-size:10px;">·</span>`}
+                        ${generatedTime && html`<span style="color:#4a6080;font-size:11px;">${generatedTime}</span>`}
+                    </div>
+                `}
                 ${isOpen && html`
                     <div onMouseEnter=${open} onMouseLeave=${closeSoon}>
                         <${Popover}>
@@ -140,60 +149,6 @@ export async function createHeader() {
                                 >${copied ? '✓' : 'Copy'}</button>
                             </div>
                         </${Popover}>
-                    </div>
-                `}
-            </div>
-        `;
-    }
-
-    // ── info icon ─────────────────────────────────────────────────────────────
-
-    function InfoIcon({ friendlyName, generatedTime }) {
-        const { isOpen, open, closeSoon } = useHoverPopover();
-        const [copied, setCopied] = useState(false);
-        const copyTimer = useRef(null);
-
-        useEffect(() => () => { if (copyTimer.current) clearTimeout(copyTimer.current); }, []);
-
-        if (!friendlyName && !generatedTime) return null;
-
-        const copy = async (e) => {
-            e.stopPropagation();
-            try {
-                await navigator.clipboard.writeText(friendlyName);
-                setCopied(true);
-                copyTimer.current = setTimeout(() => setCopied(false), 1500);
-            } catch {}
-        };
-
-        return html`
-            <div style="position:relative;" onMouseEnter=${open} onMouseLeave=${closeSoon}>
-                <button
-                    style="width:26px;height:26px;border-radius:5px;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);color:rgba(255,255,255,0.3);cursor:pointer;display:flex;align-items:center;justify-content:center;transition:all 0.15s;font-size:11px;font-style:italic;font-weight:700;line-height:1;flex-shrink:0;"
-                    title="Review info"
-                    type="button"
-                >i</button>
-                ${isOpen && html`
-                    <div
-                        style="position:absolute;right:0;top:calc(100% + 6px);${POPUP_STYLE}padding:10px 12px;min-width:210px;"
-                        onMouseEnter=${open}
-                        onMouseLeave=${closeSoon}
-                    >
-                        ${friendlyName && html`
-                            <div style="display:flex;align-items:center;justify-content:space-between;gap:10px;${generatedTime ? 'margin-bottom:7px;' : ''}">
-                                <div style="overflow:hidden;">
-                                    <span style="color:#4a6080;font-size:10px;font-weight:500;text-transform:uppercase;letter-spacing:0.05em;display:block;margin-bottom:1px;">Run name</span>
-                                    <span style="color:#c9d5e8;font-size:12px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:block;">${friendlyName}</span>
-                                </div>
-                                <button
-                                    onClick=${copy}
-                                    style="flex-shrink:0;background:rgba(255,255,255,0.07);border:1px solid rgba(255,255,255,0.12);border-radius:4px;color:${copied ? '#4ade80' : '#8899bb'};cursor:pointer;padding:2px 8px;font-size:10px;font-weight:500;transition:all 0.15s;white-space:nowrap;"
-                                >${copied ? '✓ Copied' : 'Copy'}</button>
-                            </div>
-                        `}
-                        ${generatedTime && html`
-                            <div style="color:#4a6080;font-size:11px;">${generatedTime}</div>
-                        `}
                     </div>
                 `}
             </div>
@@ -273,7 +228,8 @@ export async function createHeader() {
             if (!voteType || phase === 'submitting') return;
             setPhase('submitting');
             try {
-                const res = await fetch('/api/v1/feedback', {
+                const feedbackURL = SESSION_REVIEW_ID ? `/api/v1/feedback?r=${SESSION_REVIEW_ID}` : '/api/v1/feedback';
+                const res = await fetch(feedbackURL, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
@@ -423,12 +379,11 @@ export async function createHeader() {
                 <div class="header-top-row">
                     <div class="brand">
                         <${LogoButton} />
-                        <${BrandButton} />
+                        <${BrandButton} friendlyName=${friendlyName} generatedTime=${generatedTime} />
                     </div>
                     <div class="header-actions">
                         <${UsageChip} endpoint="/api/runtime/usage-chip" />
                         <${AppFeedback} />
-                        <${InfoIcon} friendlyName=${friendlyName} generatedTime=${generatedTime} />
                     </div>
                 </div>
             </div>

--- a/internal/staticserve/static/components/PrecommitBar.js
+++ b/internal/staticserve/static/components/PrecommitBar.js
@@ -1,6 +1,8 @@
 // PrecommitBar component - commit/push/skip actions
 import { waitForPreact } from './utils.js';
 
+const SESSION_REVIEW_ID = new URLSearchParams(window.location.search).get('r') || '';
+
 // Extract the first markdown heading as a commit message suggestion
 function extractTitleFromSummary(markdown) {
     if (!markdown) return '';
@@ -38,7 +40,8 @@ export async function createPrecommitBar() {
 
             draftDebounceRef.current = setTimeout(async () => {
                 try {
-                    const res = await fetch('/api/draft', {
+                    const draftURL = SESSION_REVIEW_ID ? `/api/draft?r=${SESSION_REVIEW_ID}` : '/api/draft';
+                    const res = await fetch(draftURL, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({
@@ -48,7 +51,7 @@ export async function createPrecommitBar() {
                     });
 
                     if (res.status === 409) {
-                        const latest = await fetch('/api/draft');
+                        const latest = await fetch(draftURL);
                         if (latest.ok) {
                             const snap = await latest.json();
                             draftVersionRef.current = snap.version || 0;
@@ -76,7 +79,7 @@ export async function createPrecommitBar() {
 
             const initDraft = async () => {
                 try {
-                    const res = await fetch('/api/draft');
+                    const res = await fetch(SESSION_REVIEW_ID ? `/api/draft?r=${SESSION_REVIEW_ID}` : '/api/draft');
                     if (!res.ok || !mounted) return;
                     const snap = await res.json();
                     draftVersionRef.current = snap.version || 0;
@@ -94,7 +97,8 @@ export async function createPrecommitBar() {
             initDraft();
 
             if (window.EventSource) {
-                source = new EventSource('/api/draft/events');
+                const draftEventsURL = SESSION_REVIEW_ID ? `/api/draft/events?r=${SESSION_REVIEW_ID}` : '/api/draft/events';
+                source = new EventSource(draftEventsURL);
                 source.onmessage = (event) => {
                     if (!mounted) return;
                     try {
@@ -157,12 +161,13 @@ export async function createPrecommitBar() {
                 setStatus('Commit message is required');
                 return;
             }
-            
+
             setDisabled(true);
             setStatus('Sending decision...');
-            
+
             try {
-                const res = await fetch(path, {
+                const url = SESSION_REVIEW_ID ? `${path}?r=${SESSION_REVIEW_ID}` : path;
+                const res = await fetch(url, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ message })

--- a/internal/staticserve/static/components/UsageBanner.js
+++ b/internal/staticserve/static/components/UsageBanner.js
@@ -2,6 +2,14 @@ import { normalizeUsagePayload } from '/static/components/usage_chip_model.mjs';
 
 const { html, useEffect, useState } = window.preact;
 
+const SESSION_REVIEW_ID = new URLSearchParams(window.location.search).get('r') || '';
+
+function withSession(endpoint) {
+    if (!SESSION_REVIEW_ID) return endpoint;
+    const sep = endpoint.includes('?') ? '&' : '?';
+    return `${endpoint}${sep}r=${SESSION_REVIEW_ID}`;
+}
+
 export function UsageBanner({ endpoint }) {
     const [chip, setChip] = useState(null);
     const [loading, setLoading] = useState(true);
@@ -10,7 +18,7 @@ export function UsageBanner({ endpoint }) {
         let cancelled = false;
         const load = async () => {
             try {
-                const response = await fetch(endpoint);
+                const response = await fetch(withSession(endpoint));
                 if (!response.ok) return;
                 const data = await response.json();
                 if (!cancelled) {

--- a/internal/staticserve/static/components/UsageChip.js
+++ b/internal/staticserve/static/components/UsageChip.js
@@ -3,9 +3,16 @@ import { formatResetAt, normalizeUsagePayload, planLabel, usageTone } from '/sta
 const { html, useEffect, useMemo, useRef, useState } = window.preact;
 
 const DEFAULT_REFRESH_MS = 5 * 60 * 1000;
+const SESSION_REVIEW_ID = new URLSearchParams(window.location.search).get('r') || '';
+
+function withSession(endpoint) {
+  if (!SESSION_REVIEW_ID) return endpoint;
+  const sep = endpoint.includes('?') ? '&' : '?';
+  return `${endpoint}${sep}r=${SESSION_REVIEW_ID}`;
+}
 
 async function fetchUsagePayload(endpoint) {
-  const response = await fetch(endpoint, {
+  const response = await fetch(withSession(endpoint), {
     headers: { 'Content-Type': 'application/json' },
   });
   if (!response.ok) {


### PR DESCRIPTION
## Summary

This PR fixes several interconnected issues where the UI had no concept of which review session it belonged to, causing stale browser tabs to silently read or act on the wrong review when a port was reused.

### Session gate (`?r=` token)

- Added `requireSession(sessionID, next)` middleware that rejects requests with a `403 session_mismatch` if the `?r=` query param doesn't match the active review ID
- Every HTTP endpoint in both the progressive and non-progressive server paths is now wrapped: `/api/review`, `/api/runtime/usage-chip`, `/api/draft`, `/api/draft/events`, `/commit`, `/commit-push`, `/skip`, `/vouch`, `/abort`, `/handoff`, `/api/v1/diff-review/`, `/api/v1/feedback`
- All served URLs now include `?r=<reviewID>` (e.g. `http://localhost:8000/?r=6837`)
- All JS fetch calls in `app.js`, `FeedbackPopup.js`, `Header.js`, `PrecommitBar.js`, `UsageBanner.js`, `UsageChip.js` forward the session param
- When a 403 is received the UI renders a "Session Ended" screen instead of silently breaking

### Feedback `review_id` always linked

- `handleFeedbackProxy` now accepts the server-side `reviewID` and injects it into the request body before forwarding, so every feedback row in the DB is always linked to the correct review — even for general (non-comment) feedback from the header

### Active reviews listing page (`GET /` without `?r=`)

- Navigating to `http://localhost:<port>/` without a session token now serves a VS Code-styled listing of all active lrc review processes on the machine
- Process discovery uses a file-based registry at `/tmp/.lrc-reviews/<port>.json`; PID liveness is checked on every read and stale files are cleaned up automatically (files are also removed on normal process exit via `defer unregister()`)
- The listing page has three side panels: **Impact Stats** (fetched from LiveReview API), **Share** (pre-filled LinkedIn-format message with copy button), and **About** (GitHub repo info with live star/fork counts and hardcoded fallback values when GitHub API is unreachable)
- PID liveness check is split into platform-specific files (`review_runtime_pid_unix.go` / `review_runtime_pid_windows.go`) so Windows gets a working `os.FindProcess`-based check instead of `kill(pid, 0)`

### Bug fixes

- **Friendly name**: UI was showing a locally-generated name instead of the server-assigned friendly name. Fixed by overriding `currentReviewState.FriendlyName` with `submitResp.FriendlyName` after submission
- **Header UX**: Run name and timestamp moved inline below "LiveReview Results" heading; hover-to-share scope tightened to the heading only; `InfoIcon` component removed
- **Local review link** added to the terminal `+ METADATA +` block alongside the LiveReview cloud link

### Security hardening in listing page

- All user/external data inserted into HTML (`FriendlyName`, `Repository`, `ReviewID`, GitHub API fields) is wrapped with `html.EscapeString`
- `rv.ReviewID` is `url.QueryEscape`d before being placed in hrefs, then `html.EscapeString`ed before embedding in `onclick` JS string context
- `registerActiveReview` now returns a no-op cleanup func on `MkdirAll`/`Marshal`/`WriteFile` errors rather than silently continuing with a half-written state
- GitHub stats and impact stats fetched concurrently (max 3s latency instead of 6s)
- Landing page HTML/CSS/JS extracted into `review_runtime_landing.go` to keep `review_runtime.go` focused on review flow logic

## Test plan

- [ ] Run `lrc` on a repo — confirm terminal shows both LiveReview cloud link and `Local review: http://localhost:<port>/?r=<id>`
- [ ] Open the local URL — confirm review loads normally with run name and timestamp below the heading
- [ ] Open `http://localhost:<port>/` (no `?r=`) — confirm VS Code-styled listing page appears with the current review in the table
- [ ] Run two `lrc` instances on different ports — confirm both appear on either listing page
- [ ] Kill one `lrc` process and reload listing — confirm dead entry is removed
- [ ] Open the review URL from a previous session on a reused port — confirm "Session Ended" screen appears instead of showing the new review's data
- [ ] Submit a thumbs-down feedback — confirm `review_id` is populated in the DB row
- [ ] Verify usage chip and usage banner load without 403 errors