### PR TITLE
Fixing Broken LRC Update 

### DIFF
--- a/internal/selfupdate/self_update.go
+++ b/internal/selfupdate/self_update.go
@@ -26,6 +26,7 @@ import (
 	"github.com/HexmosTech/git-lrc/storage"
 	"github.com/gofrs/flock"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/term"
 )
 
 // version is injected by main at startup so update checks compare against the
@@ -118,7 +119,7 @@ func fetchReleaseManifest(client *network.Client) (*network.ReleaseManifest, err
 }
 
 func fetchLatestVersionFromManifest() (string, error) {
-	client := network.NewSelfUpdateClient(30 * time.Second)
+	client := network.NewSelfUpdateClient()
 	manifest, err := fetchReleaseManifest(client)
 	if err != nil {
 		return "", err
@@ -517,7 +518,7 @@ func downloadVersionBinaryFromManifest(versionTag string) (string, error) {
 		binaryName = "lrc.exe"
 	}
 
-	client := network.NewSelfUpdateClient(120 * time.Second)
+	client := network.NewSelfUpdateClient()
 	manifest, err := fetchReleaseManifest(client)
 	if err != nil {
 		return "", err
@@ -546,7 +547,42 @@ func downloadVersionBinaryFromManifest(versionTag string) (string, error) {
 	}
 	tmpPath := tmpFile.Name()
 
-	statusCode, err := network.SelfUpdateDownloadBinaryTo(client, fullURL, tmpFile)
+	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
+	if !isTTY {
+		fmt.Printf("Downloading lrc %s ...\n", versionTag)
+	}
+	startTime := time.Now()
+	statusCode, err := network.SelfUpdateDownloadBinaryTo(client, fullURL, tmpFile, func(downloaded, total int64) {
+		if !isTTY {
+			return
+		}
+		elapsed := time.Since(startTime).Seconds()
+		if elapsed < 0.001 {
+			elapsed = 0.001
+		}
+		speedBps := float64(downloaded) / elapsed
+		speedMBps := speedBps / (1024 * 1024)
+		if total > 0 {
+			pct := float64(downloaded) * 100.0 / float64(total)
+			var etaStr string
+			if speedBps > 0 {
+				etaSecs := int(float64(total-downloaded) / speedBps)
+				if etaSecs < 60 {
+					etaStr = fmt.Sprintf("%ds", etaSecs)
+				} else {
+					etaStr = fmt.Sprintf("%dm%ds", etaSecs/60, etaSecs%60)
+				}
+			} else {
+				etaStr = "?"
+			}
+			fmt.Printf("\rDownloading lrc %s ... %.1f%% | %.1f MB/s | ETA %-6s", versionTag, pct, speedMBps, etaStr)
+		} else {
+			fmt.Printf("\rDownloading lrc %s ... %.1f MB/s | %d KB downloaded", versionTag, speedMBps, downloaded/1024)
+		}
+	})
+	if isTTY {
+		fmt.Println()
+	}
 	if err != nil {
 		_ = tmpFile.Close()
 		_ = storage.Remove(tmpPath)

--- a/internal/selfupdate/self_update.go
+++ b/internal/selfupdate/self_update.go
@@ -517,7 +517,7 @@ func downloadVersionBinaryFromManifest(versionTag string) (string, error) {
 		binaryName = "lrc.exe"
 	}
 
-	client := network.NewSelfUpdateClient(60 * time.Second)
+	client := network.NewSelfUpdateClient(120 * time.Second)
 	manifest, err := fetchReleaseManifest(client)
 	if err != nil {
 		return "", err

--- a/network/network_status.md
+++ b/network/network_status.md
@@ -64,7 +64,7 @@ This document tracks network-side operations in git-lrc as an auditable inventor
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | SelfUpdateFetchManifest | api | Update manifest metadata and checksum references | Retrieve global update manifest | Medium | Medium integrity risk if manifest source is untrusted | Compensated by controlled update source design and follow-on verification path; acceptable risk | [network/selfupdate_operations.go](selfupdate_operations.go#L32) |
 | SelfUpdateFetchReleaseManifest | api | Platform-specific release manifest | Retrieve release details for current target platform | Medium | Medium integrity risk from release metadata tampering | Compensated by expected-host model and verification pipeline assumptions; acceptable risk | [network/selfupdate_operations.go](selfupdate_operations.go#L37) |
-| SelfUpdateDownloadBinaryTo | api | Binary stream bytes for executable update artifact | Download release binary to target path | High | High integrity and supply-chain risk for executable download | Compensated by source host validation and SHA256 verification during staging in internal/selfupdate downloadVersionBinaryFromManifest; residual risk acceptable | [network/selfupdate_operations.go](selfupdate_operations.go#L45) |
+| SelfUpdateDownloadBinaryTo | api | Binary stream bytes for executable update artifact | Download release binary to target path | High | High integrity and supply-chain risk for executable download | Compensated by source host validation and SHA256 verification during staging in internal/selfupdate downloadVersionBinaryFromManifest; residual risk acceptable | [network/selfupdate_operations.go](selfupdate_operations.go#L62) |
 
 ## Inventory: HTTP Transport And Error Handling Utilities
 

--- a/network/selfupdate_client.go
+++ b/network/selfupdate_client.go
@@ -1,8 +1,6 @@
 package network
 
-import "time"
-
 // NewSelfUpdateClient creates an HTTP client for self-update network operations.
-func NewSelfUpdateClient(timeout time.Duration) *Client {
-	return NewClient(timeout)
+func NewSelfUpdateClient() *Client {
+	return NewClient(0)
 }

--- a/network/selfupdate_operations.go
+++ b/network/selfupdate_operations.go
@@ -41,8 +41,25 @@ func SelfUpdateFetchReleaseManifest(client *Client, fullURL string) (*Response, 
 	return client.DoJSON(http.MethodGet, fullURL, nil, "", "", nil)
 }
 
+// progressWriter wraps an io.Writer and calls onProgress after each write.
+type progressWriter struct {
+	dst        io.Writer
+	total      int64
+	downloaded int64
+	onProgress func(downloaded, total int64)
+}
+
+func (pw *progressWriter) Write(p []byte) (int, error) {
+	n, err := pw.dst.Write(p)
+	pw.downloaded += int64(n)
+	pw.onProgress(pw.downloaded, pw.total)
+	return n, err
+}
+
 // SelfUpdateDownloadBinaryTo streams a self-update binary into dst.
-func SelfUpdateDownloadBinaryTo(client *Client, fullURL string, dst io.Writer) (int, error) {
+// onProgress is called after each chunk with (downloaded, total) byte counts;
+// total is -1 when the server does not send Content-Length.
+func SelfUpdateDownloadBinaryTo(client *Client, fullURL string, dst io.Writer, onProgress func(downloaded, total int64)) (int, error) {
 	if err := validateSelfUpdateURL(fullURL); err != nil {
 		return 0, err
 	}
@@ -58,7 +75,8 @@ func SelfUpdateDownloadBinaryTo(client *Client, fullURL string, dst io.Writer) (
 	}
 	defer resp.Body.Close()
 
-	if _, err := io.Copy(dst, resp.Body); err != nil {
+	pw := &progressWriter{dst: dst, total: resp.ContentLength, onProgress: onProgress}
+	if _, err := io.Copy(pw, resp.Body); err != nil {
 		return resp.StatusCode, fmt.Errorf("failed to stream self-update body: %w", err)
 	}
 


### PR DESCRIPTION
In this discussion https://github.com/HexmosTech/git-lrc/issues/74#issuecomment-4529253391 developer had issues with updating `git-lrc`.
```
PS C:\Users\tejas> git-lrc update
Current version: v0.3.7
Checking for updates...
Latest version:  v0.3.8

⬆ Update available: v0.3.7 → v0.3.8
Downloading update artifact...
Error: failed to stage update: failed to download update binary: failed to stream self-update body: context deadline exceeded (Client.Timeout or context cancellation while reading body)
```

The root cause of the issues was there was a context timeout of the whole application download.

Fixed it by removing the context deadline. 

Adding ETA and progress of the downloading application.