### PR TITLE
DeepSeek connector: add V4 models (deepseek-v4-pro / deepseek-v4-flash)

### DIFF
--- a/internal/staticserve/static/ui-connectors/providers.js
+++ b/internal/staticserve/static/ui-connectors/providers.js
@@ -11,8 +11,8 @@ export const providers = [
   {
     id: 'deepseek',
     name: 'DeepSeek',
-    defaultModel: 'deepseek-chat',
-    models: ['deepseek-chat', 'deepseek-r1'],
+    defaultModel: 'deepseek-v4-flash',
+    models: ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-chat', 'deepseek-r1'],
     apiKeyPlaceholder: 'sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
     baseURLPlaceholder: 'https://api.deepseek.com/v1',
   },


### PR DESCRIPTION
## What

Add DeepSeek's current **V4** models to the DeepSeek BYOK connector and make `deepseek-v4-flash` the recommended default, while keeping the existing `deepseek-chat` / `deepseek-r1` options for backward compatibility.

```diff
-    defaultModel: 'deepseek-chat',
-    models: ['deepseek-chat', 'deepseek-r1'],
+    defaultModel: 'deepseek-v4-flash',
+    models: ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-chat', 'deepseek-r1'],
```

## Why

The DeepSeek connector only offered the legacy `deepseek-chat` / `deepseek-r1` models. Because the model picker for non-Ollama providers is a fixed `<select>` populated solely from `provider.models`, users had no way to select DeepSeek's current V4 models (`deepseek-v4-pro`, `deepseek-v4-flash`) per the [official API docs](https://api-docs.deepseek.com/zh-cn/api/create-chat-completion).

Closes #103.

## Verification

- **DeepSeek API direct**: `POST https://api.deepseek.com/chat/completions` with `model: "deepseek-v4-pro"` → HTTP 200, response echoes `"model":"deepseek-v4-pro"`.
- **Full lrc path** (`lrc ui` → `/api/ui/connectors/validate-key` → LiveReview cloud → DeepSeek):
  - `deepseek-v4-pro` → `{"valid":true}`
  - `deepseek-v4-flash` (implicitly via default) — accepted
  - bogus model id → `{"valid":false}` (control: confirms the cloud actually probes the model, not just the key)
- `go build ./...` and `node --check providers.js` pass.

## Scope

UI-only change to `internal/staticserve/static/ui-connectors/providers.js`; no backend changes.
