### PR TITLE
feat: add --terminal flag for CLI-only review output

### DIFF
--- a/hooks/prepare-commit-msg.sh
+++ b/hooks/prepare-commit-msg.sh
@@ -147,7 +147,11 @@ fi
 # Run review
 if [ "$LRC_INTERACTIVE" = "1" ]; then
 	echo "Running LiveReview commit check..." >&2
-	LRC_ACTIVE_COMMIT_MSG_FILE="$COMMIT_MSG_FILE" LRC_INITIAL_MESSAGE_FILE="$INITIAL_MSG_FILE" lrc review --staged --precommit
+	if [ "${LRC_TERMINAL:-}" = "1" ]; then
+		LRC_ACTIVE_COMMIT_MSG_FILE="$COMMIT_MSG_FILE" LRC_INITIAL_MESSAGE_FILE="$INITIAL_MSG_FILE" lrc review --staged --precommit --terminal
+	else
+		LRC_ACTIVE_COMMIT_MSG_FILE="$COMMIT_MSG_FILE" LRC_INITIAL_MESSAGE_FILE="$INITIAL_MSG_FILE" lrc review --staged --precommit
+	fi
 	REVIEW_EXIT=$?
 else
 	LRC_ACTIVE_COMMIT_MSG_FILE="$COMMIT_MSG_FILE" LRC_INITIAL_MESSAGE_FILE="$INITIAL_MSG_FILE" lrc review --staged --output json >/dev/null 2>&1

--- a/internal/appcore/interactive_decision_test.go
+++ b/internal/appcore/interactive_decision_test.go
@@ -81,3 +81,115 @@ func TestExecuteDecisionDeferredCommitWritesLiveCommitMessageWhenProvided(t *tes
 		t.Fatalf("expected no override file at %q, stat err = %v", overridePath, statErr)
 	}
 }
+
+func TestParseTerminalDecision(t *testing.T) {
+	initialMsg := "feat: test initial message"
+
+	tests := []struct {
+		name        string
+		input       string
+		wantCode    int
+		wantMsg     string
+		wantPush    bool
+		wantMatched bool
+	}{
+		{
+			name:        "empty input (Enter) commits with initial message",
+			input:       "",
+			wantCode:    0,
+			wantMsg:     initialMsg,
+			wantPush:    false,
+			wantMatched: true,
+		},
+		{
+			name:        "spaces input (Enter with whitespace) commits with initial message",
+			input:       "   \n",
+			wantCode:    0,
+			wantMsg:     initialMsg,
+			wantPush:    false,
+			wantMatched: true,
+		},
+		{
+			name:        "input 's' skips",
+			input:       "s",
+			wantCode:    2,
+			wantMsg:     initialMsg,
+			wantPush:    false,
+			wantMatched: true,
+		},
+		{
+			name:        "input 'S' with whitespace skips",
+			input:       "  S  \n",
+			wantCode:    2,
+			wantMsg:     initialMsg,
+			wantPush:    false,
+			wantMatched: true,
+		},
+		{
+			name:        "input 'v' vouches",
+			input:       "v",
+			wantCode:    4,
+			wantMsg:     initialMsg,
+			wantPush:    false,
+			wantMatched: true,
+		},
+		{
+			name:        "input 'V' vouches",
+			input:       "V",
+			wantCode:    4,
+			wantMsg:     initialMsg,
+			wantPush:    false,
+			wantMatched: true,
+		},
+		{
+			name:        "input 'a' aborts",
+			input:       "a",
+			wantCode:    1,
+			wantMsg:     "",
+			wantPush:    false,
+			wantMatched: true,
+		},
+		{
+			name:        "input 'A' aborts",
+			input:       "A",
+			wantCode:    1,
+			wantMsg:     "",
+			wantPush:    false,
+			wantMatched: true,
+		},
+		{
+			name:        "unknown input does not match",
+			input:       "invalid",
+			wantCode:    0,
+			wantMsg:     "",
+			wantPush:    false,
+			wantMatched: false,
+		},
+		{
+			name:        "unknown single character does not match",
+			input:       "x",
+			wantCode:    0,
+			wantMsg:     "",
+			wantPush:    false,
+			wantMatched: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code, msg, push, matched := parseTerminalDecision(tc.input, initialMsg)
+			if code != tc.wantCode {
+				t.Errorf("code = %d, want %d", code, tc.wantCode)
+			}
+			if msg != tc.wantMsg {
+				t.Errorf("msg = %q, want %q", msg, tc.wantMsg)
+			}
+			if push != tc.wantPush {
+				t.Errorf("push = %v, want %v", push, tc.wantPush)
+			}
+			if matched != tc.wantMatched {
+				t.Errorf("matched = %v, want %v", matched, tc.wantMatched)
+			}
+		})
+	}
+}

--- a/internal/appcore/review_runtime.go
+++ b/internal/appcore/review_runtime.go
@@ -1541,34 +1541,34 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 
 			exitCode := precommitExitCodeForDecision(code)
 			if commitMsgPath != "" {
-					if exitCode == decisionflow.DecisionCommit {
-						msgToPersist := msg
-						if strings.TrimSpace(msgToPersist) == "" {
-							msgToPersist = initialMsg
-						}
-						if strings.TrimSpace(msgToPersist) != "" {
-							if liveCommitMsgPath != "" {
-								if err := persistActiveCommitMessage(liveCommitMsgPath, msgToPersist); err != nil {
-									fmt.Fprintf(os.Stderr, "Warning: failed to store live commit message: %v\n", err)
-								}
-							} else if err := persistCommitMessage(commitMsgPath, msgToPersist); err != nil {
-								fmt.Fprintf(os.Stderr, "Warning: failed to store commit message: %v\n", err)
+				if exitCode == decisionflow.DecisionCommit {
+					msgToPersist := msg
+					if strings.TrimSpace(msgToPersist) == "" {
+						msgToPersist = initialMsg
+					}
+					if strings.TrimSpace(msgToPersist) != "" {
+						if liveCommitMsgPath != "" {
+							if err := persistActiveCommitMessage(liveCommitMsgPath, msgToPersist); err != nil {
+								fmt.Fprintf(os.Stderr, "Warning: failed to store live commit message: %v\n", err)
 							}
+						} else if err := persistCommitMessage(commitMsgPath, msgToPersist); err != nil {
+							fmt.Fprintf(os.Stderr, "Warning: failed to store commit message: %v\n", err)
 						}
-					} else {
-						_ = clearCommitMessageFile(commitMsgPath)
 					}
-
-					if exitCode == decisionflow.DecisionCommit && push {
-						if err := persistPushRequest(commitMsgPath); err != nil {
-							fmt.Fprintf(os.Stderr, "Warning: failed to store push request: %v\n", err)
-						}
-					} else {
-						_ = clearPushRequest(commitMsgPath)
-					}
+				} else {
+					_ = clearCommitMessageFile(commitMsgPath)
 				}
-				return cli.Exit("", exitCode)
+
+				if exitCode == decisionflow.DecisionCommit && push {
+					if err := persistPushRequest(commitMsgPath); err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: failed to store push request: %v\n", err)
+					}
+				} else {
+					_ = clearPushRequest(commitMsgPath)
+				}
 			}
+			return cli.Exit("", exitCode)
+		}
 	}
 
 	// Only write attestation for pre-commit reviews, not post-commit reviews
@@ -1823,6 +1823,27 @@ func renderPretty(result *reviewmodel.DiffReviewResponse) error {
 	return nil
 }
 
+// parseTerminalDecision processes a raw input string from the terminal prompt
+func parseTerminalDecision(input string, initialMsg string) (code int, msg string, push bool, matched bool) {
+	input = strings.TrimSpace(strings.ToLower(input))
+	switch input {
+	case "":
+		// Commit with existing message
+		return 0, initialMsg, false, true
+	case "s":
+		// Skip review
+		return 2, initialMsg, false, true
+	case "v":
+		// Vouch (DecisionVouch = 4)
+		return 4, initialMsg, false, true
+	case "a":
+		// Abort
+		return 1, "", false, true
+	default:
+		return 0, "", false, false
+	}
+}
+
 // terminalDecisionPrompt shows a simple terminal prompt for commit/skip/vouch decisions
 func terminalDecisionPrompt(initialMsg string, result *reviewmodel.DiffReviewResponse) (int, string, bool, error) {
 	// Check if stdin is a terminal, if not try to open /dev/tty
@@ -1850,28 +1871,23 @@ func terminalDecisionPrompt(initialMsg string, result *reviewmodel.DiffReviewRes
 		if err != nil {
 			return 0, "", false, fmt.Errorf("failed to read input: %w", err)
 		}
-		input = strings.TrimSpace(strings.ToLower(input))
 
-		switch input {
-		case "":
-			// Commit with existing message
-			fmt.Println("Committing...")
-			return 0, initialMsg, false, nil
-		case "s":
-			// Skip review
-			fmt.Println("Skipping review, committing anyway...")
-			return 2, initialMsg, false, nil
-		case "v":
-			// Vouch (DecisionVouch = 4)
-			fmt.Println("Vouching for changes...")
-			return 4, initialMsg, false, nil
-		case "a":
-			// Abort
-			fmt.Println("Aborting commit.")
-			return 1, "", false, nil
-		default:
-			fmt.Printf("Unknown option: %s. Please try again.\n", input)
+		code, msg, push, matched := parseTerminalDecision(input, initialMsg)
+		if matched {
+			switch code {
+			case 0:
+				fmt.Println("Committing...")
+			case 2:
+				fmt.Println("Skipping review, committing anyway...")
+			case 4:
+				fmt.Println("Vouching for changes...")
+			case 1:
+				fmt.Println("Aborting commit.")
+			}
+			return code, msg, push, nil
 		}
+
+		fmt.Printf("Unknown option: %s. Please try again.\n", strings.TrimSpace(input))
 	}
 }
 

--- a/internal/appcore/review_runtime.go
+++ b/internal/appcore/review_runtime.go
@@ -273,6 +273,11 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 		}
 	}
 
+	// Apply terminal mode from config if not explicitly set via CLI flag
+	if !opts.Terminal && config.Terminal {
+		opts.Terminal = true
+	}
+
 	// Determine repo name
 	repoName := opts.RepoName
 	if repoName == "" {
@@ -449,7 +454,8 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 
 	// Generate and serve skeleton HTML immediately if --serve is enabled
 	// Auto-enable serve when no HTML path specified and not in post-commit mode
-	autoServeEnabled := !opts.Serve && opts.SaveHTML == "" && !isPostCommitReview
+	// Skip auto-serve if terminal mode is enabled
+	autoServeEnabled := !opts.Serve && opts.SaveHTML == "" && !isPostCommitReview && !opts.Terminal
 	if autoServeEnabled {
 		opts.Serve = true
 	}
@@ -1515,6 +1521,58 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 		}
 	}
 
+	// Terminal mode: show results in terminal and handle decision if precommit
+	if opts.Terminal && !opts.Serve {
+		if err := renderResult(result, opts.Output); err != nil {
+			return fmt.Errorf("failed to render result: %w", err)
+		}
+
+		// If in precommit mode, prompt for decision
+		if opts.Precommit && !isPostCommitReview {
+			code, msg, push, err := terminalDecisionPrompt(initialMsg, result)
+			if err != nil {
+				return fmt.Errorf("terminal decision failed: %w", err)
+			}
+
+			// Handle the decision
+			if err := ensureAttestation(attestationAction, verbose, &attestationWritten); err != nil {
+				return err
+			}
+
+			if opts.Precommit {
+				exitCode := precommitExitCodeForDecision(code)
+				if commitMsgPath != "" {
+					if exitCode == decisionflow.DecisionCommit {
+						msgToPersist := msg
+						if strings.TrimSpace(msgToPersist) == "" {
+							msgToPersist = initialMsg
+						}
+						if strings.TrimSpace(msgToPersist) != "" {
+							if liveCommitMsgPath != "" {
+								if err := persistActiveCommitMessage(liveCommitMsgPath, msgToPersist); err != nil {
+									fmt.Fprintf(os.Stderr, "Warning: failed to store live commit message: %v\n", err)
+								}
+							} else if err := persistCommitMessage(commitMsgPath, msgToPersist); err != nil {
+								fmt.Fprintf(os.Stderr, "Warning: failed to store commit message: %v\n", err)
+							}
+						}
+					} else {
+						_ = clearCommitMessageFile(commitMsgPath)
+					}
+
+					if exitCode == decisionflow.DecisionCommit && push {
+						if err := persistPushRequest(commitMsgPath); err != nil {
+							fmt.Fprintf(os.Stderr, "Warning: failed to store push request: %v\n", err)
+						}
+					} else {
+						_ = clearPushRequest(commitMsgPath)
+					}
+				}
+				return cli.Exit("", exitCode)
+			}
+		}
+	}
+
 	// Only write attestation for pre-commit reviews, not post-commit reviews
 	if !isPostCommitReview {
 		if err := ensureAttestation(attestationAction, verbose, &attestationWritten); err != nil {
@@ -1767,6 +1825,48 @@ func renderPretty(result *reviewmodel.DiffReviewResponse) error {
 	return nil
 }
 
+// terminalDecisionPrompt shows a simple terminal prompt for commit/skip/vouch decisions
+func terminalDecisionPrompt(initialMsg string, result *reviewmodel.DiffReviewResponse) (int, string, bool, error) {
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Println("\n" + strings.Repeat("-", 80))
+		fmt.Println("Review complete. Choose an action:")
+		fmt.Println("  [Enter]  Commit (with optional message)")
+		fmt.Println("  [s]      Skip review and commit anyway")
+		fmt.Println("  [v]      Vouch for changes without AI review")
+		fmt.Println("  [a]      Abort commit")
+		fmt.Print("> ")
+
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			return 0, "", false, fmt.Errorf("failed to read input: %w", err)
+		}
+		input = strings.TrimSpace(strings.ToLower(input))
+
+		switch input {
+		case "":
+			// Commit with existing message
+			fmt.Println("Committing...")
+			return 0, initialMsg, false, nil
+		case "s":
+			// Skip review
+			fmt.Println("Skipping review, committing anyway...")
+			return 2, initialMsg, false, nil
+		case "v":
+			// Vouch
+			fmt.Println("Vouching for changes...")
+			return 2, initialMsg, false, nil
+		case "a":
+			// Abort
+			fmt.Println("Aborting commit.")
+			return 1, "", false, nil
+		default:
+			fmt.Printf("Unknown option: %s. Please try again.\n", input)
+		}
+	}
+}
+
 func printEnvelopeUsageSummary(label string, envelope *reviewmodel.PlanUsageEnvelope) {
 	if envelope == nil {
 		return
@@ -1851,6 +1951,7 @@ type Config struct {
 	JWT          string
 	RefreshToken string
 	ConfigPath   string
+	Terminal     bool
 }
 
 // loadConfigValues attempts to load configuration from ~/.lrc.toml, then applies CLI/env overrides
@@ -1911,6 +2012,7 @@ func loadConfigValues(apiKeyOverride, apiURLOverride string, verbose bool) (*Con
 		config.OrgID = strings.TrimSpace(k.String("org_id"))
 		config.JWT = strings.TrimSpace(k.String("jwt"))
 		config.RefreshToken = strings.TrimSpace(k.String("refresh_token"))
+		config.Terminal = k.Bool("terminal")
 	}
 
 	return config, nil

--- a/internal/appcore/review_runtime.go
+++ b/internal/appcore/review_runtime.go
@@ -1515,7 +1515,7 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 	}
 
 	// Render result to stdout (skip in interactive mode or when serving - handled by UI)
-	if !useDecisionUI && !opts.Serve {
+	if !useDecisionUI && !opts.Serve && !opts.Terminal {
 		if err := renderResult(result, opts.Output); err != nil {
 			return fmt.Errorf("failed to render result: %w", err)
 		}
@@ -1539,9 +1539,8 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 				return err
 			}
 
-			if opts.Precommit {
-				exitCode := precommitExitCodeForDecision(code)
-				if commitMsgPath != "" {
+			exitCode := precommitExitCodeForDecision(code)
+			if commitMsgPath != "" {
 					if exitCode == decisionflow.DecisionCommit {
 						msgToPersist := msg
 						if strings.TrimSpace(msgToPersist) == "" {
@@ -1570,7 +1569,6 @@ func runReviewWithOptions(opts reviewopts.Options) error {
 				}
 				return cli.Exit("", exitCode)
 			}
-		}
 	}
 
 	// Only write attestation for pre-commit reviews, not post-commit reviews
@@ -1827,7 +1825,17 @@ func renderPretty(result *reviewmodel.DiffReviewResponse) error {
 
 // terminalDecisionPrompt shows a simple terminal prompt for commit/skip/vouch decisions
 func terminalDecisionPrompt(initialMsg string, result *reviewmodel.DiffReviewResponse) (int, string, bool, error) {
-	reader := bufio.NewReader(os.Stdin)
+	// Check if stdin is a terminal, if not try to open /dev/tty
+	inFile := os.Stdin
+	if !term.IsTerminal(int(inFile.Fd())) {
+		tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+		if err != nil {
+			return 0, "", false, fmt.Errorf("stdin is not a terminal and cannot open /dev/tty: %w", err)
+		}
+		defer tty.Close()
+		inFile = tty
+	}
+	reader := bufio.NewReader(inFile)
 
 	for {
 		fmt.Println("\n" + strings.Repeat("-", 80))
@@ -1854,9 +1862,9 @@ func terminalDecisionPrompt(initialMsg string, result *reviewmodel.DiffReviewRes
 			fmt.Println("Skipping review, committing anyway...")
 			return 2, initialMsg, false, nil
 		case "v":
-			// Vouch
+			// Vouch (DecisionVouch = 4)
 			fmt.Println("Vouching for changes...")
-			return 2, initialMsg, false, nil
+			return 4, initialMsg, false, nil
 		case "a":
 			// Abort
 			fmt.Println("Aborting commit.")

--- a/internal/reviewopts/options.go
+++ b/internal/reviewopts/options.go
@@ -43,6 +43,7 @@ type Options struct {
 	Force                 bool
 	Vouch                 bool
 	InitialMsg            string
+	Terminal              bool
 }
 
 func BuildFromContext(c *cli.Context, includeDebug bool) (Options, error) {
@@ -76,6 +77,7 @@ func BuildFromContext(c *cli.Context, includeDebug bool) (Options, error) {
 		SaveJSON:              c.String("save-json"),
 		SaveText:              c.String("save-text"),
 		InitialMsg:            initialMsg,
+		Terminal:              c.Bool("terminal"),
 	}
 
 	if opts.Skip || opts.Vouch {
@@ -111,7 +113,7 @@ func BuildFromContext(c *cli.Context, includeDebug bool) (Options, error) {
 		diffSource = "commit"
 		opts.Precommit = false
 		opts.Skip = false
-		if !c.IsSet("serve") && !c.IsSet("save-html") {
+		if !c.IsSet("serve") && !c.IsSet("save-html") && !opts.Terminal {
 			opts.Serve = true
 		}
 	} else if opts.RangeVal != "" {
@@ -144,6 +146,11 @@ func BuildFromContext(c *cli.Context, includeDebug bool) (Options, error) {
 
 	if opts.Output == "" {
 		opts.Output = DefaultOutputFormat
+	}
+
+	// If terminal mode is explicitly enabled, ensure serve is disabled
+	if opts.Terminal {
+		opts.Serve = false
 	}
 
 	return opts, nil

--- a/internal/reviewopts/options_test.go
+++ b/internal/reviewopts/options_test.go
@@ -54,11 +54,43 @@ func TestBuildFromContextBlockingReview(t *testing.T) {
 	})
 }
 
+func TestBuildFromContextTerminal(t *testing.T) {
+	t.Run("terminal mode disables serve", func(t *testing.T) {
+		ctx := newOptionsTestContext(t, []string{"--terminal"})
+
+		opts, err := BuildFromContext(ctx, false)
+		if err != nil {
+			t.Fatalf("BuildFromContext() error = %v", err)
+		}
+		if !opts.Terminal {
+			t.Fatalf("Terminal = false, want true")
+		}
+		if opts.Serve {
+			t.Fatalf("Serve = true, want false (terminal mode must disable serve)")
+		}
+	})
+
+	t.Run("terminal mode with commit disables serve", func(t *testing.T) {
+		ctx := newOptionsTestContext(t, []string{"--terminal", "--commit", "HEAD"})
+
+		opts, err := BuildFromContext(ctx, false)
+		if err != nil {
+			t.Fatalf("BuildFromContext() error = %v", err)
+		}
+		if !opts.Terminal {
+			t.Fatalf("Terminal = false, want true")
+		}
+		if opts.Serve {
+			t.Fatalf("Serve = true, want false (terminal mode must override commit auto-serve)")
+		}
+	})
+}
+
 func newOptionsTestContext(t *testing.T, args []string) *cli.Context {
 	t.Helper()
 
 	set := flag.NewFlagSet("reviewopts-test", flag.ContinueOnError)
-	for _, boolName := range []string{"staged", "serve", "verbose", "precommit", "blocking-review", "skip", "force", "vouch"} {
+	for _, boolName := range []string{"staged", "serve", "verbose", "precommit", "blocking-review", "skip", "force", "vouch", "terminal"} {
 		set.Bool(boolName, false, "")
 	}
 	for _, stringName := range []string{"repo-name", "range", "commit", "diff-file", "api-url", "api-key", "output", "save-html", "save-json", "save-text", "diff-source"} {

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ var baseFlags = []cli.Flag{
 	&cli.BoolFlag{Name: "skip", Usage: "mark review as skipped and write attestation without contacting the API", EnvVars: []string{"LRC_SKIP"}},
 	&cli.BoolFlag{Name: "force", Usage: "force rerun by removing existing attestation/hash for current tree", EnvVars: []string{"LRC_FORCE"}},
 	&cli.BoolFlag{Name: "vouch", Usage: "vouch for changes manually without running AI review (records attestation with coverage stats from prior iterations)", EnvVars: []string{"LRC_VOUCH"}},
+	&cli.BoolFlag{Name: "terminal", Aliases: []string{"t"}, Usage: "display review results in terminal instead of opening browser", EnvVars: []string{"LRC_TERMINAL"}},
 }
 
 var debugFlags = []cli.Flag{


### PR DESCRIPTION
# feat: add --terminal flag for CLI-only review output (#43)

## Description
This PR addresses Discussion #43 ("Add CLI-Based Review Output") by implementing a `--terminal` (`-t`) flag. This enables users to render review results directly in the terminal, bypassing the browser UI entirely. This is particularly useful for:
- Remote or cloud workspaces where browser access is unavailable.
- CI/CD integration.
- Fast, terminal-native feedback loops.

## Changes
- **CLI Flags**: Added `--terminal` (`-t`) flag to the `review` command (`main.go`). Supports environment variable `LRC_TERMINAL=1`.
- **Options Parsing**: Added `Terminal` to options and ensured it explicitly disables/overrides automatic server startup (`opts.Serve = false`).
- **Terminal Decision Flow**: Added a clean terminal prompt `terminalDecisionPrompt` in pre-commit mode to select between Committing (Enter), Skipping (s), Vouching (v), or Aborting (a).
- **Graceful TTY Fallback**: Checks if stdin is a terminal, falling back to `/dev/tty` if run within Git hooks where stdin may be redirected.
- **Config Support**: Supports setting `terminal = true` in `~/.lrc.toml` as a user preference.
- **Hook Integration**: Updated `prepare-commit-msg.sh` to leverage the `--terminal` flag when `LRC_TERMINAL=1` is exported.

## Testing & Architecture Quality
- Refactored prompt logic into a pure function `parseTerminalDecision` to allow thorough unit-testing without hanging or requiring a terminal environment.
- Added **10 state transition unit tests** inside `internal/appcore/interactive_decision_test.go` to test all input scenarios (whitespace, capital letters, Enter, invalid inputs).
- Added option-combination unit tests inside `internal/reviewopts/options_test.go`.
- Validated style against the codebase with `go fmt ./...` and `go vet ./...`.

Closes #43