### PR TITLE
Clarify Go version guidance in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ This keeps the project focused and avoids PRs that arrive before the problem has
 
 ## Getting Started Locally
 
-Use the Go version declared in [go.mod](./go.mod). At the time of writing, that is Go 1.25.10.
+Use the Go version declared in [go.mod](./go.mod).
 
 Build and install git-lrc locally with:
 


### PR DESCRIPTION
## Summary

Removes a stale hardcoded Go patch version from `CONTRIBUTING.md` and keeps `go.mod` as the source of truth for the required Go version.

## Linked Issue

N/A - small documentation correction.

## Validation

- Checked `go.mod`, `CONTRIBUTING.md`, README, docs, GitHub workflow files, and the Makefile for stale Go version references.
- Ran `git diff --check`.
- No Go or JS tests run because this is a docs-only change.

## Notes For Reviewers

No behavior changes. This only avoids contributor confusion when `go.mod` is updated.
