### PR TITLE
Preserve PascalCase comments when appending streamed review comments

### DIFF
--- a/internal/staticserve/static/components/review_stream_state.mjs
+++ b/internal/staticserve/static/components/review_stream_state.mjs
@@ -142,7 +142,9 @@ export function appendStreamedCommentsToFiles(files, incomingComments) {
     }
 
     const nextFiles = files.map((file) => {
-        const existingComments = Array.isArray(file?.comments) ? file.comments : [];
+        const lowerComments = Array.isArray(file?.comments) ? file.comments : [];
+        const pascalComments = Array.isArray(file?.Comments) ? file.Comments : [];
+        const existingComments = lowerComments.length > 0 ? lowerComments : pascalComments;
         return {
             ...file,
             comments: [...existingComments]

--- a/internal/staticserve/static/components/review_stream_state.test.mjs
+++ b/internal/staticserve/static/components/review_stream_state.test.mjs
@@ -108,6 +108,21 @@ test('appendStreamedCommentsToFiles appends matching comments without mutating i
     assert.equal(nextFiles[1].comments[0].content, 'new-b');
 });
 
+test('appendStreamedCommentsToFiles preserves PascalCase comments from API payloads', () => {
+    const files = [
+        { FilePath: 'a.go', Comments: [{ Line: 1, Content: 'existing', Severity: 'info', Category: 'review' }] },
+    ];
+
+    const nextFiles = appendStreamedCommentsToFiles(files, [
+        { file_path: 'a.go', line: 2, content: 'streamed', severity: 'warning', category: 'review' },
+    ]);
+
+    assert.equal(files[0].comments, undefined);
+    assert.equal(nextFiles[0].comments.length, 2);
+    assert.equal(nextFiles[0].comments[0].Content, 'existing');
+    assert.equal(nextFiles[0].comments[1].content, 'streamed');
+});
+
 test('inferReviewStatusFromEvents prefers explicit status and falls back to completion', () => {
     assert.equal(inferReviewStatusFromEvents([
         { type: 'completion', data: { resultSummary: 'ok' } },


### PR DESCRIPTION
## Summary

Preserves existing PascalCase `Comments` entries when streamed review comments are appended to file payloads.

## Why

Initial review payloads can use the API-style `Comments` field while streamed comments are appended into the UI's lowercase `comments` field. Without preserving both shapes, existing comments can disappear after a streamed update.

## Validation

- `node --test internal/staticserve/static/components/review_stream_state.test.mjs`
- `node --test internal/staticserve/static/components/*.test.mjs`
- `git diff --check`

Note: `make test-js` could not run locally because `make` is not installed in this PowerShell environment; the equivalent Node test command from the Makefile passed.
