### PR TITLE
Preserve Markdown table formatting in summary text view

### DIFF
--- a/internal/staticserve/static/components/Summary.js
+++ b/internal/staticserve/static/components/Summary.js
@@ -3,8 +3,8 @@ import { waitForPreact } from './utils.js';
 import { getSummarySlideshow } from './SummarySlideshow/SummarySlideshow.js';
 
 const ALLOWED_TAGS = new Set([
-    'A', 'BLOCKQUOTE', 'BR', 'CODE', 'EM', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
-    'HR', 'LI', 'OL', 'P', 'PRE', 'STRONG', 'UL'
+    'A', 'BLOCKQUOTE', 'BR', 'CAPTION', 'CODE', 'COL', 'COLGROUP', 'EM', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
+    'HR', 'LI', 'OL', 'P', 'PRE', 'STRONG', 'TABLE', 'TBODY', 'TD', 'TFOOT', 'TH', 'THEAD', 'TR', 'UL'
 ]);
 
 const SAFE_URL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);

--- a/internal/staticserve/static/styles.css
+++ b/internal/staticserve/static/styles.css
@@ -922,6 +922,34 @@ body {
   margin-bottom: 0.9em;
 }
 
+.summary-text-content table {
+  width: 100%;
+  margin: 12px 0 16px;
+  border-collapse: collapse;
+  border: 1px solid var(--border-medium);
+  border-radius: 8px;
+  overflow: hidden;
+  font-size: 13px;
+}
+
+.summary-text-content th,
+.summary-text-content td {
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  text-align: left;
+  vertical-align: top;
+}
+
+.summary-text-content th {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.summary-text-content td {
+  background: rgba(255, 255, 255, 0.02);
+}
+
 .summary-slideshow-embedded {
   width: 100%;
   outline: none;


### PR DESCRIPTION
## Summary

Preserves Markdown table structure in the review summary Text view.

## Why

The slideshow summary sanitizer already allows table elements, but the regular summary Text view sanitizer stripped table tags. That flattened Markdown tables into hard-to-scan text even though the same summary could render as a table elsewhere.

This keeps the sanitizer behavior consistent and adds compact dark-theme table styling for the Text view.

## Before / After

![Before and after summary table rendering](https://gist.githubusercontent.com/sayedrisat/a03bcfb77af4acaea3120e1f629e3afb/raw/git-lrc-summary-table-before-after.svg)

Before: table content was flattened into plain text.

After: headers, rows, borders, and dark-theme styling are preserved.

## Validation

- `node --test internal/staticserve/static/components/*.test.mjs`
- `git diff --check`

Note: `make test-js` could not run locally because `make` is not installed in this PowerShell environment; the equivalent Node test command from the Makefile passed.
