### PR TITLE
fix: block sudo execution with clear error message

### DIFF
--- a/scripts/lrc-install.sh
+++ b/scripts/lrc-install.sh
@@ -263,6 +263,12 @@ if [ "$RELEASE_CHANNEL" = "internal" ]; then
 fi
 
 # Install location (user-writable, no sudo needed)
+# Install location (user-writable, no sudo needed)
+if [ "$(id -u)" -eq 0 ]; then
+    echo -e "${RED}Error: Do not run this installer with sudo. Run as your normal user:${NC}"
+    echo "  curl -fsSL https://hexmos.com/lrc-install.sh | bash"
+    exit 1
+fi
 INSTALL_DIR="$HOME/.local/bin"
 INSTALL_PATH="$INSTALL_DIR/lrc"
 GIT_INSTALL_PATH="$INSTALL_DIR/git-lrc"


### PR DESCRIPTION
## Summary

The installer script had no guard against being run with sudo. When run with sudo, $HOME resolves to root's home directory, causing the install to fail with a misleading error.

## Linked Issue

Closes #121

## Validation

- Ran `sudo bash lrc-install.sh` → exits immediately with clear error message
- Ran `bash lrc-install.sh` → installs normally to ~/.local/bin
- Tested on macOS (darwin-arm64)

## Notes For Reviewers

The fix is a single early-exit block added before the INSTALL_DIR 
declaration. No existing logic was modified.