### PR TITLE
Show pre-rename callers in the blast-radius dependency graph

### DIFF
--- a/blastradius/blastradius.go
+++ b/blastradius/blastradius.go
@@ -154,6 +154,12 @@ type CallerRef struct {
 	// Path holds the intermediate qualified names between the symbol and
 	// this caller (see CallerContribution.Path).
 	Path []string
+	// PreRename marks a caller reached via the symbol's pre-rename name
+	// rather than the graph's CALLS edges: it references the old name and
+	// breaks until it's migrated. CALLS fan-in can never find these - the
+	// index reflects the post-rename tree, where the old name has no node
+	// and every edge pointing at it was dropped as unresolvable.
+	PreRename bool
 }
 
 // SymbolContribution describes one touched symbol's part of a hunk's score.
@@ -182,7 +188,14 @@ type SymbolContribution struct {
 	TransitiveCount int
 	// Callers is the full caller list (only for "calls"), sorted by depth
 	// then name, for showing exactly which transitive calls contributed.
+	// A renamed symbol additionally carries its pre-rename callers here,
+	// flagged with CallerRef.PreRename - see RenamedFrom.
 	Callers []CallerRef
+	// RenamedFrom is the pre-rename name when this symbol's own declaration
+	// was renamed in the diff, empty otherwise. It explains why the entries
+	// in Callers flagged PreRename are there: they still reference this
+	// name, so they break until they're migrated.
+	RenamedFrom string
 	// ImpactedPackages are the distinct packages/directories this symbol's
 	// influence reaches: for "calls", the packages its callers live in; for
 	// "text-references", the directories search_code found matches in.
@@ -632,6 +645,17 @@ func ScoreHunks(ctx context.Context, project string, hunks []Hunk, opts ...Optio
 		impactedPackages := sortedUnique(packages)
 
 		rename, renamed := renameByQN[qn]
+		// A renamed symbol's CALLS fan-in above only sees callers already
+		// migrated to the new name - usually none, which is why the graph
+		// looked empty for exactly the highest-risk case. The pre-rename
+		// callers are the ones about to break, so append them (display and
+		// visualization only; they contribute no points - the rename's score
+		// stays entirely in renameOldNameSignal below).
+		if renamed {
+			preRename := oldNameCallers(ctx, c, rename, qn)
+			callers = append(callers, preRename...)
+			callers = append(callers, expandPreRenameCallers(ctx, c, preRename, o.Score, qn)...)
+		}
 		callerReachDetail := fmt.Sprintf("%d direct + %d transitive caller(s), up to %d hops", direct, transitive, maxDepth)
 		if renamed {
 			callerReachDetail = fmt.Sprintf("%d direct + %d transitive caller(s) already migrated to the new name %q, up to %d hops", direct, transitive, rename.NewName, maxDepth)
@@ -706,6 +730,7 @@ func ScoreHunks(ctx context.Context, project string, hunks []Hunk, opts ...Optio
 			DirectCount:      direct,
 			TransitiveCount:  transitive,
 			Callers:          callers,
+			RenamedFrom:      rename.OldName, // zero value when !renamed
 			ImpactedPackages: impactedPackages,
 		}
 	}
@@ -818,11 +843,24 @@ func ScoreHunks(ctx context.Context, project string, hunks []Hunk, opts ...Optio
 				}
 			}
 
+			// A renamed type has no call graph of its own (that's what makes
+			// it a "text-references" symbol), but the places still using its
+			// old name are real, locatable nodes - so a renamed struct gets a
+			// dependency graph here where it previously had nothing to show.
+			var callers []CallerRef
+			if renamed {
+				preRename := oldNameCallers(ctx, c, rename, qn)
+				callers = append(callers, preRename...)
+				callers = append(callers, expandPreRenameCallers(ctx, c, preRename, o.Score, qn)...)
+			}
+
 			contribByQN[qn] = SymbolContribution{
 				Method:            "text-references",
 				Signals:           signals,
 				BlastRadiusRaw:    sumSignalPoints(signals, blastRadiusCategories),
 				DirectCount:       refs,
+				Callers:           callers,
+				RenamedFrom:       rename.OldName, // zero value when !renamed
 				ImpactedPackages:  usage.Directories,
 				MethodBlastRadius: methodBlastRadius,
 			}

--- a/blastradius/client/client.go
+++ b/blastradius/client/client.go
@@ -158,6 +158,64 @@ func (c *Client) SearchCodeUsage(ctx context.Context, pattern string) (*CodeUsag
 	return &CodeUsage{TotalMatches: result.TotalGrepMatches, Directories: dirs}, nil
 }
 
+// CodeSymbolMatch is one textual hit resolved to the graph node that encloses
+// it - search_code's "compact" mode maps each grep match back to the symbol
+// whose source range contains it, which is what makes it usable as a caller
+// list for names that have no node of their own (see SearchCodeSymbols).
+type CodeSymbolMatch struct {
+	QualifiedName string `json:"qualified_name"`
+	Name          string `json:"node"`
+	Label         string `json:"label"`
+	File          string `json:"file"`
+	StartLine     int    `json:"start_line"`
+	// MatchLines are the 1-based line numbers inside this symbol where the
+	// pattern actually occurred.
+	MatchLines []int `json:"match_lines"`
+}
+
+// CodeSymbolMatches is the result of SearchCodeSymbols.
+type CodeSymbolMatches struct {
+	// Matches are the enclosing symbols, deduplicated by the tool itself
+	// (one entry per symbol, however many lines inside it matched).
+	Matches []CodeSymbolMatch
+	// TotalMatches is the raw grep-style hit count, the same number
+	// SearchCodeUsage reports - unaffected by the enrichment limit.
+	TotalMatches int
+	// Truncated reports that the tool found more enclosing symbols than the
+	// limit allowed it to enrich, so Matches is a partial list.
+	Truncated bool
+}
+
+// SearchCodeSymbols runs `cli search_code --mode compact` for pattern and
+// returns the graph symbols enclosing each match. Unlike SearchCodeUsage
+// (which only counts hits), this identifies *who* references the name - the
+// only way to find references to a name the graph has no node for, e.g. a
+// symbol's pre-rename name after the tree was reindexed. limit <= 0 leaves
+// the tool's own default in place.
+func (c *Client) SearchCodeSymbols(ctx context.Context, pattern string, limit int) (*CodeSymbolMatches, error) {
+	args := []string{"--pattern", pattern, "--mode", "compact"}
+	if limit > 0 {
+		args = append(args, "--limit", strconv.Itoa(limit))
+	}
+	out, err := c.run(ctx, "search_code", args...)
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		Results          []CodeSymbolMatch `json:"results"`
+		TotalGrepMatches int               `json:"total_grep_matches"`
+		TotalResults     int               `json:"total_results"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("blastradius/client: parsing search_code output: %w", err)
+	}
+	return &CodeSymbolMatches{
+		Matches:      result.Results,
+		TotalMatches: result.TotalGrepMatches,
+		Truncated:    result.TotalResults > len(result.Results),
+	}, nil
+}
+
 // ArchitectureEntryPoint is one entry in get_architecture's "entry_points"
 // aspect - a real, cross-language entry point (main functions, extension
 // activate/deactivate hooks, script mains), not just the is_entry_point

--- a/blastradius/rename.go
+++ b/blastradius/rename.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/HexmosTech/blastradius/client"
+	"github.com/HexmosTech/blastradius/score"
 	"github.com/HexmosTech/blastradius/symbols"
 )
 
@@ -115,33 +117,172 @@ func matchSingleIdentSwap(oldLine, newLine, symName string) *DeclRename {
 
 // renameOldNameSignal runs a best-effort text search for rn.OldName and
 // returns a Signal counting how many places in the repo still reference the
-// pre-rename name - i.e. call sites/references that are about to break until
-// they're migrated to rn.NewName. Weighted 1.5x relative to the plain
-// sqrt(refs) used for an ordinary text-reference count elsewhere in this
-// package, since this is live, unmigrated breakage risk right now, not just
-// historical usage. Unlike the ordinary text-reference count, no "-1 for the
-// symbol's own definition" adjustment is applied: the definition itself was
-// renamed away, so every remaining match under the old name is an external
-// reference.
+// pre-rename name after the declaration moved to rn.NewName. Weighted 1.5x
+// relative to the plain sqrt(refs) used for an ordinary text-reference count
+// elsewhere in this package, since an unmigrated reference is a live risk
+// right now, not just historical usage. Unlike the ordinary text-reference
+// count, no "-1 for the symbol's own definition" adjustment is applied: the
+// definition itself was renamed away, so every remaining match under the old
+// name is an external reference.
+//
+// The wording states only what was measured. search_code is grep-based, so a
+// match can equally be a real call, a comment, or a string literal - calling
+// these references "about to break" asserted a compile failure that nothing
+// here verifies. Points are unchanged; this is phrasing only.
 func renameOldNameSignal(ctx context.Context, c *client.Client, rn DeclRename) Signal {
 	usage, err := c.SearchCodeUsage(ctx, rn.OldName)
 	if err != nil {
 		// Distinguish "checked, found nothing" from "couldn't check" - the
 		// latter must not silently read as 0 points/0 references, which
-		// would falsely assert the rename is safe when it simply wasn't
-		// verified.
+		// would falsely assert the rename is fully migrated when it simply
+		// wasn't verified.
 		return Signal{
-			Name:     "Callers of old name (about to break)",
-			Detail:   fmt.Sprintf("could not check references to the pre-rename name %q: %v", rn.OldName, err),
+			Name:     "Still uses the old name",
+			Detail:   fmt.Sprintf("could not check references to the old name %q: %v", rn.OldName, err),
 			Points:   0,
 			Category: "graph",
 		}
 	}
 	refs := usage.TotalMatches
 	return Signal{
-		Name:     "Callers of old name (about to break)",
-		Detail:   fmt.Sprintf("%d reference(s) to the pre-rename name %q still exist and will break until migrated to %q", refs, rn.OldName, rn.NewName),
+		Name:     "Still uses the old name",
+		Detail:   fmt.Sprintf("%d reference(s) to %q remain after the rename to %q", refs, rn.OldName, rn.NewName),
 		Points:   1.5 * math.Sqrt(float64(refs)),
 		Category: "graph",
 	}
+}
+
+// oldNameCallerLimit caps how many enclosing symbols search_code is asked to
+// resolve for a pre-rename name. Generous enough that a normal rename's call
+// sites all fit, bounded so a rename of a very common word (e.g. "get") can't
+// turn one hunk into a thousand-node graph.
+const oldNameCallerLimit = 60
+
+// preRenameCallerLabels are the node labels that can actually contain a
+// reference that breaks. search_code resolves a match to whatever node encloses
+// it, which includes documentation and structural nodes (Section, File, Folder,
+// Package, ...) - a README mentioning the old name is not a caller, and listing
+// it as one would misrepresent the breakage.
+var preRenameCallerLabels = map[string]bool{
+	"Function": true,
+	"Method":   true,
+	"Class":    true,
+	"Struct":   true,
+	"Variable": true,
+	"Route":    true,
+}
+
+// oldNameCallers finds the symbols that still reference rn.OldName - the call
+// sites that break until they're migrated to rn.NewName - and returns them as
+// depth-1 CallerRefs flagged PreRename.
+//
+// These cannot come from CALLS fan-in: the graph is indexed against the
+// post-rename tree, so the old name has no node and every edge that pointed at
+// it was dropped as unresolvable. search_code's compact mode is the way in - it
+// resolves each textual hit to the graph node enclosing it, which is exactly
+// the caller we want.
+//
+// Best-effort by the same rule as renameOldNameSignal's error path: a failed
+// lookup returns no callers rather than failing the report. It contributes no
+// points either way - scoring stays entirely with renameOldNameSignal.
+func oldNameCallers(ctx context.Context, c *client.Client, rn DeclRename, selfQN string) []CallerRef {
+	matches, err := c.SearchCodeSymbols(ctx, rn.OldName, oldNameCallerLimit)
+	if err != nil {
+		return nil
+	}
+	return preRenameCallersFrom(matches.Matches, selfQN)
+}
+
+// preRenameCallersFrom is oldNameCallers' pure half: turn search_code's
+// enclosing-symbol matches into a deduplicated, name-sorted caller list.
+func preRenameCallersFrom(matches []client.CodeSymbolMatch, selfQN string) []CallerRef {
+	var callers []CallerRef
+	seen := make(map[string]bool)
+	for _, m := range matches {
+		// The renamed symbol's own declaration is not one of its callers.
+		// It can still match: a method body referencing its own old name,
+		// or a stale doc comment above the new declaration.
+		if m.QualifiedName == "" || m.QualifiedName == selfQN || seen[m.QualifiedName] {
+			continue
+		}
+		if !preRenameCallerLabels[m.Label] {
+			continue
+		}
+		seen[m.QualifiedName] = true
+		callers = append(callers, CallerRef{
+			QualifiedName: m.QualifiedName,
+			Depth:         1,
+			Weight:        1,
+			PreRename:     true,
+		})
+	}
+	sort.Slice(callers, func(i, j int) bool { return callers[i].QualifiedName < callers[j].QualifiedName })
+	return callers
+}
+
+// expandPreRenameCallers adds the transitive fan-in of direct pre-rename
+// callers. Unlike the old name itself, those callers are ordinary present-day
+// graph nodes, so score.FanIn can walk them - which is what gives a rename's
+// sunburst/flamegraph the same depth structure as any other symbol's instead of
+// a single flat ring.
+//
+// Each discovered caller comes back one hop further from the renamed symbol
+// than it is from the direct caller, reached *through* that direct caller, so
+// its Depth is shifted by 1 and its Path prefixed accordingly. Anything already
+// present as a direct pre-rename caller is left alone - the shallower depth is
+// the truthful one.
+func expandPreRenameCallers(ctx context.Context, q score.GraphQuerier, direct []CallerRef, cfg score.Config, selfQN string) []CallerRef {
+	if len(direct) == 0 {
+		return nil
+	}
+	directQN := make([]string, 0, len(direct))
+	seen := make(map[string]bool, len(direct))
+	for _, c := range direct {
+		directQN = append(directQN, c.QualifiedName)
+		seen[c.QualifiedName] = true
+	}
+	// One fewer hop than a normal walk: the direct pre-rename callers are
+	// already one hop out from the renamed symbol, so the budget left for
+	// their own callers is MaxDepth-1.
+	expandCfg := cfg
+	expandCfg.MaxDepth = cfg.MaxDepth - 1
+	if expandCfg.MaxDepth < 1 {
+		return nil
+	}
+	scores, err := score.FanIn(ctx, q, directQN, expandCfg)
+	if err != nil {
+		return nil // best-effort: the direct callers alone are still worth showing
+	}
+
+	best := make(map[string]CallerRef)
+	for viaQN, ss := range scores {
+		for _, cc := range ss.Callers {
+			qn := cc.QualifiedName
+			if qn == "" || qn == selfQN || seen[qn] {
+				continue
+			}
+			depth := cc.Depth + 1
+			if existing, ok := best[qn]; ok && existing.Depth <= depth {
+				continue
+			}
+			best[qn] = CallerRef{
+				QualifiedName: qn,
+				Depth:         depth,
+				Weight:        cc.Weight * cfg.Decay,
+				Path:          append([]string{viaQN}, cc.Path...),
+				PreRename:     true,
+			}
+		}
+	}
+	expanded := make([]CallerRef, 0, len(best))
+	for _, c := range best {
+		expanded = append(expanded, c)
+	}
+	sort.Slice(expanded, func(i, j int) bool {
+		if expanded[i].Depth != expanded[j].Depth {
+			return expanded[i].Depth < expanded[j].Depth
+		}
+		return expanded[i].QualifiedName < expanded[j].QualifiedName
+	})
+	return expanded
 }

--- a/blastradius/rename_callers_test.go
+++ b/blastradius/rename_callers_test.go
@@ -1,0 +1,128 @@
+package blastradius
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/HexmosTech/blastradius/client"
+	"github.com/HexmosTech/blastradius/score"
+)
+
+func TestPreRenameCallersFromFiltersAndDedups(t *testing.T) {
+	matches := []client.CodeSymbolMatch{
+		{QualifiedName: "pkg.main", Label: "Function"},
+		// The renamed symbol's own declaration is not one of its callers -
+		// it matches because a stale doc comment still names it.
+		{QualifiedName: "pkg.RuHelp", Label: "Function"},
+		// A README section mentioning the old name is not a caller.
+		{QualifiedName: "docs.README.Help", Label: "Section"},
+		{QualifiedName: "pkg.handler", Label: "Method"},
+		// The tool can report the same enclosing symbol twice.
+		{QualifiedName: "pkg.main", Label: "Function"},
+		{QualifiedName: "pkg.registry", Label: "Variable"},
+		// Structural nodes carry no call site of their own.
+		{QualifiedName: "pkg", Label: "Package"},
+		{QualifiedName: "", Label: "Function"},
+	}
+
+	got := preRenameCallersFrom(matches, "pkg.RuHelp")
+
+	want := []string{"pkg.handler", "pkg.main", "pkg.registry"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d callers %+v, want %d", len(got), got, len(want))
+	}
+	for i, qn := range want {
+		if got[i].QualifiedName != qn {
+			t.Fatalf("caller[%d] = %q, want %q (results must be name-sorted)", i, got[i].QualifiedName, qn)
+		}
+		if got[i].Depth != 1 {
+			t.Errorf("caller %q Depth = %d, want 1", qn, got[i].Depth)
+		}
+		if !got[i].PreRename {
+			t.Errorf("caller %q PreRename = false, want true", qn)
+		}
+	}
+}
+
+func TestPreRenameCallersFromNoMatches(t *testing.T) {
+	if got := preRenameCallersFrom(nil, "pkg.RuHelp"); got != nil {
+		t.Fatalf("got %+v, want nil for an empty match list", got)
+	}
+	// A fully-migrated rename: the only remaining hit is the symbol itself.
+	only := []client.CodeSymbolMatch{{QualifiedName: "pkg.RuHelp", Label: "Function"}}
+	if got := preRenameCallersFrom(only, "pkg.RuHelp"); got != nil {
+		t.Fatalf("got %+v, want nil when the only match is the symbol itself", got)
+	}
+}
+
+// chainQuerier answers depth-1 fan-in for a fixed caller->callee chain:
+// pkg.top -> pkg.mid -> pkg.direct. Deeper queries return nothing, so a walk
+// terminates naturally.
+type chainQuerier struct{}
+
+func (chainQuerier) QueryGraph(ctx context.Context, cypher string, maxRows int) (*client.QueryResult, error) {
+	// score.FanIn's depth-1 query is the only single-hop MATCH it issues.
+	if !strings.Contains(cypher, "(caller)-[:CALLS]->(f)") {
+		return &client.QueryResult{Columns: []string{"symbol", "caller"}}, nil
+	}
+	rows := [][]string{{"pkg.direct", "pkg.mid"}}
+	if strings.Contains(cypher, "pkg.mid") {
+		rows = append(rows, []string{"pkg.mid", "pkg.top"})
+	}
+	return &client.QueryResult{Columns: []string{"symbol", "caller"}, Rows: rows}, nil
+}
+
+func TestExpandPreRenameCallersShiftsDepthAndPath(t *testing.T) {
+	direct := []CallerRef{{QualifiedName: "pkg.direct", Depth: 1, Weight: 1, PreRename: true}}
+	cfg := score.Config{MaxDepth: 3, Decay: 0.5}
+
+	got := expandPreRenameCallers(context.Background(), chainQuerier{}, direct, cfg, "pkg.RuHelp")
+
+	if len(got) != 1 {
+		t.Fatalf("got %d expanded callers %+v, want 1", len(got), got)
+	}
+	c := got[0]
+	if c.QualifiedName != "pkg.mid" {
+		t.Fatalf("QualifiedName = %q, want pkg.mid", c.QualifiedName)
+	}
+	// pkg.mid is 1 hop from pkg.direct, which is itself 1 hop from the
+	// renamed symbol - so 2 from the symbol, reached through pkg.direct.
+	if c.Depth != 2 {
+		t.Errorf("Depth = %d, want 2 (one hop further than the direct caller)", c.Depth)
+	}
+	if len(c.Path) != 1 || c.Path[0] != "pkg.direct" {
+		t.Errorf("Path = %v, want [pkg.direct]", c.Path)
+	}
+	if !c.PreRename {
+		t.Error("PreRename = false, want true - the whole branch reaches via the old name")
+	}
+}
+
+func TestExpandPreRenameCallersSkipsAlreadyDirectCallers(t *testing.T) {
+	// pkg.mid is already a direct pre-rename caller, so its rediscovery at
+	// depth 2 must not add a duplicate at the deeper depth.
+	direct := []CallerRef{
+		{QualifiedName: "pkg.direct", Depth: 1, Weight: 1, PreRename: true},
+		{QualifiedName: "pkg.mid", Depth: 1, Weight: 1, PreRename: true},
+	}
+	cfg := score.Config{MaxDepth: 3, Decay: 0.5}
+
+	for _, c := range expandPreRenameCallers(context.Background(), chainQuerier{}, direct, cfg, "pkg.RuHelp") {
+		if c.QualifiedName == "pkg.mid" {
+			t.Fatalf("pkg.mid re-added at depth %d despite already being a direct caller", c.Depth)
+		}
+	}
+}
+
+func TestExpandPreRenameCallersEmptyInput(t *testing.T) {
+	cfg := score.Config{MaxDepth: 3, Decay: 0.5}
+	if got := expandPreRenameCallers(context.Background(), chainQuerier{}, nil, cfg, "pkg.X"); got != nil {
+		t.Fatalf("got %+v, want nil when there are no direct pre-rename callers", got)
+	}
+	// MaxDepth 1 leaves no hop budget for expansion.
+	direct := []CallerRef{{QualifiedName: "pkg.direct", Depth: 1, Weight: 1, PreRename: true}}
+	if got := expandPreRenameCallers(context.Background(), chainQuerier{}, direct, score.Config{MaxDepth: 1, Decay: 0.5}, "pkg.X"); got != nil {
+		t.Fatalf("got %+v, want nil when MaxDepth leaves no room to expand", got)
+	}
+}

--- a/internal/staticserve/static/components/BlastRadiusPanel.js
+++ b/internal/staticserve/static/components/BlastRadiusPanel.js
@@ -11,15 +11,7 @@
 import { waitForPreact } from './utils.js';
 import { renderIcon } from './icons.js';
 import { blastRadiusTier, allSignals } from './blast_radius_sort_state.mjs';
-import {
-    callerGroupLabel,
-    callersForRenameView,
-    groupCallers,
-    hasRenameViews,
-    RENAME_VIEW_AFTER,
-    RENAME_VIEW_BEFORE,
-    symbolForRenameView,
-} from './callgraph_model.mjs';
+import { callerGroupLabel, groupCallers } from './callgraph_model.mjs';
 import { getSunburstChart } from './SunburstChart.js';
 import { getFlameGraph } from './FlameGraph.js';
 
@@ -404,36 +396,6 @@ export async function createBlastRadiusPanel() {
         `;
     }
 
-    // RenameViewToggle only appears for renamed symbols - everything else has
-    // a single call graph, and offering a Before/After choice there would
-    // imply a distinction that does not exist. Each side shows its own count
-    // so an empty view is obviously empty rather than looking broken.
-    function RenameViewToggle({ sym, view, onSelect }) {
-        if (!hasRenameViews(sym)) return null;
-        const beforeCount = callersForRenameView(sym, RENAME_VIEW_BEFORE).length;
-        const afterCount = callersForRenameView(sym, RENAME_VIEW_AFTER).length;
-        const newName = sym.Name || shortName(sym.QualifiedName);
-        return html`
-            <div class="blast-rename-toggle">
-                <span class="blast-rename-toggle-label">Call graph</span>
-                <button
-                    class=${view === RENAME_VIEW_BEFORE ? 'active' : ''}
-                    title="Symbols still using the old name ${sym.RenamedFrom} — found by text search, since the old name has no node left in the graph"
-                    onClick=${() => onSelect(RENAME_VIEW_BEFORE)}
-                >
-                    Before <span class="blast-rename-toggle-count">${beforeCount}</span>
-                </button>
-                <button
-                    class=${view === RENAME_VIEW_AFTER ? 'active' : ''}
-                    title="Callers of the new name ${newName} in the current graph"
-                    onClick=${() => onSelect(RENAME_VIEW_AFTER)}
-                >
-                    After <span class="blast-rename-toggle-count">${afterCount}</span>
-                </button>
-            </div>
-        `;
-    }
-
     function CallerGroup({ group, oldName, hoveredCaller, onHoverCaller }) {
         const callers = group.callers;
         const [showAll, setShowAll] = useState(false);
@@ -730,18 +692,17 @@ export async function createBlastRadiusPanel() {
         const [vizMode, setVizMode] = useState('sunburst');
         const [hoveredCaller, setHoveredCaller] = useState(null);
         const [scoreMode, setScoreMode] = useState('summary');
-        // Renamed symbols open on "Before": the After graph is the honest
-        // current state but is almost always empty right after a rename, so
-        // landing there shows nothing and reads as a broken chart.
-        const [renameView, setRenameView] = useState(RENAME_VIEW_BEFORE);
-        // Memoized because symbolForRenameView returns a fresh object for a
-        // renamed symbol: the charts key their render effect on symbol
-        // identity, so rebuilding it every parent render (each hover, each
-        // toggle elsewhere in the panel) would redraw the whole chart.
-        const vizSymbol = useMemo(
-            () => symbolForRenameView(symbols[selectedIdx], renameView),
-            [symbols, selectedIdx, renameView],
-        );
+        // The chart must only ever draw genuine CALLS-graph edges - a
+        // symbol's pre-rename callers are found by text search, not a real
+        // graph edge, and drawing one as an arc/bar would claim a call that
+        // was never observed. That analysis stays in the left column's
+        // CallerGroup (fed from sym.Callers directly, unfiltered); this
+        // strips it back out before anything reaches the chart.
+        const chartSymbol = useMemo(() => {
+            const sym = symbols[selectedIdx];
+            if (!sym || !sym.RenamedFrom) return sym;
+            return { ...sym, Callers: (sym.Callers || []).filter((c) => !c.PreRename) };
+        }, [symbols, selectedIdx]);
 
         return html`
             <div class="blast-panel">
@@ -833,15 +794,10 @@ export async function createBlastRadiusPanel() {
                                     ${renderIcon(html, 'reorder', { size: 12 })} Flamegraph
                                 </button>
                             </div>
-                            <${RenameViewToggle}
-                                sym=${symbols[selectedIdx]}
-                                view=${renameView}
-                                onSelect=${setRenameView}
-                            />
                             <div class="blast-viz-wrapper">
                                 ${vizMode === 'sunburst'
-                                    ? html`<${SunburstChart} symbol=${vizSymbol} view=${renameView} width=${SUNBURST_SIZE} height=${SUNBURST_SIZE} hoveredCaller=${hoveredCaller} onHoverCaller=${setHoveredCaller} />`
-                                    : html`<${FlameGraph} symbol=${vizSymbol} view=${renameView} width=${SUNBURST_SIZE} height=${SUNBURST_SIZE} hoveredCaller=${hoveredCaller} onHoverCaller=${setHoveredCaller} />`
+                                    ? html`<${SunburstChart} symbol=${chartSymbol} width=${SUNBURST_SIZE} height=${SUNBURST_SIZE} hoveredCaller=${hoveredCaller} onHoverCaller=${setHoveredCaller} />`
+                                    : html`<${FlameGraph} symbol=${chartSymbol} width=${SUNBURST_SIZE} height=${SUNBURST_SIZE} hoveredCaller=${hoveredCaller} onHoverCaller=${setHoveredCaller} />`
                                 }
                             </div>
                         </div>

--- a/internal/staticserve/static/components/BlastRadiusPanel.js
+++ b/internal/staticserve/static/components/BlastRadiusPanel.js
@@ -11,6 +11,15 @@
 import { waitForPreact } from './utils.js';
 import { renderIcon } from './icons.js';
 import { blastRadiusTier, allSignals } from './blast_radius_sort_state.mjs';
+import {
+    callerGroupLabel,
+    callersForRenameView,
+    groupCallers,
+    hasRenameViews,
+    RENAME_VIEW_AFTER,
+    RENAME_VIEW_BEFORE,
+    symbolForRenameView,
+} from './callgraph_model.mjs';
 import { getSunburstChart } from './SunburstChart.js';
 import { getFlameGraph } from './FlameGraph.js';
 
@@ -143,23 +152,8 @@ function sumExpression(nums) {
     return { text, total };
 }
 
-function groupCallersByDepth(callers) {
-    const groups = new Map();
-    (callers || []).forEach((c) => {
-        const depth = c.Depth || 1;
-        if (!groups.has(depth)) groups.set(depth, []);
-        groups.get(depth).push(c);
-    });
-    return [...groups.entries()].sort((a, b) => a[0] - b[0]);
-}
-
-function depthLabel(depth) {
-    if (depth === 1) return 'Direct callers';
-    return `${depth} calls away`;
-}
-
 export async function createBlastRadiusPanel() {
-    const { html, useState, useRef, useCallback, useEffect } = await waitForPreact();
+    const { html, useState, useRef, useCallback, useEffect, useMemo } = await waitForPreact();
     const SunburstChart = await getSunburstChart();
     const FlameGraph = await getFlameGraph();
 
@@ -410,21 +404,52 @@ export async function createBlastRadiusPanel() {
         `;
     }
 
-    function CallerGroup({ depth, callers, hoveredCaller, onHoverCaller }) {
+    // RenameViewToggle only appears for renamed symbols - everything else has
+    // a single call graph, and offering a Before/After choice there would
+    // imply a distinction that does not exist. Each side shows its own count
+    // so an empty view is obviously empty rather than looking broken.
+    function RenameViewToggle({ sym, view, onSelect }) {
+        if (!hasRenameViews(sym)) return null;
+        const beforeCount = callersForRenameView(sym, RENAME_VIEW_BEFORE).length;
+        const afterCount = callersForRenameView(sym, RENAME_VIEW_AFTER).length;
+        const newName = sym.Name || shortName(sym.QualifiedName);
+        return html`
+            <div class="blast-rename-toggle">
+                <span class="blast-rename-toggle-label">Call graph</span>
+                <button
+                    class=${view === RENAME_VIEW_BEFORE ? 'active' : ''}
+                    title="Symbols still using the old name ${sym.RenamedFrom} — found by text search, since the old name has no node left in the graph"
+                    onClick=${() => onSelect(RENAME_VIEW_BEFORE)}
+                >
+                    Before <span class="blast-rename-toggle-count">${beforeCount}</span>
+                </button>
+                <button
+                    class=${view === RENAME_VIEW_AFTER ? 'active' : ''}
+                    title="Callers of the new name ${newName} in the current graph"
+                    onClick=${() => onSelect(RENAME_VIEW_AFTER)}
+                >
+                    After <span class="blast-rename-toggle-count">${afterCount}</span>
+                </button>
+            </div>
+        `;
+    }
+
+    function CallerGroup({ group, oldName, hoveredCaller, onHoverCaller }) {
+        const callers = group.callers;
         const [showAll, setShowAll] = useState(false);
         const visible = showAll ? callers : callers.slice(0, CALLERS_PREVIEW);
         const hidden = callers.length - visible.length;
         return html`
-            <div class="blast-caller-group">
+            <div class="blast-caller-group ${group.preRename ? 'pre-rename' : ''}">
                 <div class="blast-caller-group-header">
-                    ${depthLabel(depth)}
+                    ${callerGroupLabel(group, oldName)}
                     <span class="blast-caller-count">${callers.length}</span>
                 </div>
                 <div class="blast-caller-list ${showAll ? 'expanded' : ''}">
                     ${visible.map((c) => html`
                         <span
                             key=${c.QualifiedName}
-                            class="blast-caller ${hoveredCaller === c.QualifiedName ? 'highlighted' : ''}"
+                            class="blast-caller ${group.preRename ? 'pre-rename' : ''} ${hoveredCaller === c.QualifiedName ? 'highlighted' : ''}"
                             title="${c.QualifiedName}"
                             onMouseEnter=${() => onHoverCaller(c.QualifiedName)}
                             onMouseLeave=${() => onHoverCaller(null)}
@@ -485,7 +510,7 @@ export async function createBlastRadiusPanel() {
     }
 
     function SymbolDetail({ sym, hoveredCaller, onHoverCaller }) {
-        const callerGroups = groupCallersByDepth(sym.Callers);
+        const callerGroups = groupCallers(sym.Callers);
         const totalCallers = (sym.Callers || []).length;
         return html`
             <div class="blast-symbol-detail">
@@ -498,8 +523,8 @@ export async function createBlastRadiusPanel() {
                 ${totalCallers > 0 && html`
                     <div class="blast-callers">
                         <div class="blast-section-title">Reached from ${totalCallers} caller${totalCallers !== 1 ? 's' : ''}</div>
-                        ${callerGroups.map(([depth, callers]) => html`
-                            <${CallerGroup} key=${depth} depth=${depth} callers=${callers} hoveredCaller=${hoveredCaller} onHoverCaller=${onHoverCaller} />
+                        ${callerGroups.map((group) => html`
+                            <${CallerGroup} key=${group.key} group=${group} oldName=${sym.RenamedFrom} hoveredCaller=${hoveredCaller} onHoverCaller=${onHoverCaller} />
                         `)}
                     </div>
                 `}
@@ -705,6 +730,18 @@ export async function createBlastRadiusPanel() {
         const [vizMode, setVizMode] = useState('sunburst');
         const [hoveredCaller, setHoveredCaller] = useState(null);
         const [scoreMode, setScoreMode] = useState('summary');
+        // Renamed symbols open on "Before": the After graph is the honest
+        // current state but is almost always empty right after a rename, so
+        // landing there shows nothing and reads as a broken chart.
+        const [renameView, setRenameView] = useState(RENAME_VIEW_BEFORE);
+        // Memoized because symbolForRenameView returns a fresh object for a
+        // renamed symbol: the charts key their render effect on symbol
+        // identity, so rebuilding it every parent render (each hover, each
+        // toggle elsewhere in the panel) would redraw the whole chart.
+        const vizSymbol = useMemo(
+            () => symbolForRenameView(symbols[selectedIdx], renameView),
+            [symbols, selectedIdx, renameView],
+        );
 
         return html`
             <div class="blast-panel">
@@ -796,10 +833,15 @@ export async function createBlastRadiusPanel() {
                                     ${renderIcon(html, 'reorder', { size: 12 })} Flamegraph
                                 </button>
                             </div>
+                            <${RenameViewToggle}
+                                sym=${symbols[selectedIdx]}
+                                view=${renameView}
+                                onSelect=${setRenameView}
+                            />
                             <div class="blast-viz-wrapper">
                                 ${vizMode === 'sunburst'
-                                    ? html`<${SunburstChart} symbol=${symbols[selectedIdx]} width=${SUNBURST_SIZE} height=${SUNBURST_SIZE} hoveredCaller=${hoveredCaller} onHoverCaller=${setHoveredCaller} />`
-                                    : html`<${FlameGraph} symbol=${symbols[selectedIdx]} width=${SUNBURST_SIZE} height=${SUNBURST_SIZE} hoveredCaller=${hoveredCaller} onHoverCaller=${setHoveredCaller} />`
+                                    ? html`<${SunburstChart} symbol=${vizSymbol} view=${renameView} width=${SUNBURST_SIZE} height=${SUNBURST_SIZE} hoveredCaller=${hoveredCaller} onHoverCaller=${setHoveredCaller} />`
+                                    : html`<${FlameGraph} symbol=${vizSymbol} view=${renameView} width=${SUNBURST_SIZE} height=${SUNBURST_SIZE} hoveredCaller=${hoveredCaller} onHoverCaller=${setHoveredCaller} />`
                                 }
                             </div>
                         </div>

--- a/internal/staticserve/static/components/FlameGraph.js
+++ b/internal/staticserve/static/components/FlameGraph.js
@@ -1,5 +1,5 @@
 import { waitForPreact } from './utils.js';
-import { buildHierarchy, DEPTH_COLORS, renderHoverTooltip, loadD3, verifyChartRender } from './callgraph-utils.js';
+import { buildHierarchy, DEPTH_COLORS, PRERENAME_COLORS, renderHoverTooltip, emptyCallGraphMessage, loadD3, verifyChartRender } from './callgraph-utils.js';
 
 // renderFlameGraph owns d3 rendering only; tooltip content/visibility is
 // reported via onHover(info, x, y) rather than mutated directly on a ref'd
@@ -9,7 +9,7 @@ import { buildHierarchy, DEPTH_COLORS, renderHoverTooltip, loadD3, verifyChartRe
 // SunburstChart.js and its use below). immediate=true skips every entrance
 // transition and snaps bars straight to their final width/position/opacity
 // - used for the automatic repair pass after a verification failure.
-function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onHoverCaller, immediate) {
+function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onHoverCaller, immediate, view) {
     const d3 = window.d3;
     const PAD_L = 4;
     const PAD_R = 4;
@@ -26,7 +26,7 @@ function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onH
         svg.append('text').attr('x', width / 2).attr('y', height / 2)
             .attr('text-anchor', 'middle').attr('fill', '#8a7060').attr('font-size', '13px')
             .attr('font-family', '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif')
-            .text('No callers in the dependency graph');
+            .text(emptyCallGraphMessage(symbol, view));
         return 0;
     }
 
@@ -57,9 +57,10 @@ function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onH
         grad.append('stop').attr('offset', '0%').attr('stop-color', from).attr('stop-opacity', 1);
         grad.append('stop').attr('offset', '100%').attr('stop-color', to).attr('stop-opacity', 1);
     }
-    function depthGradientId(depth) {
-        const c = DEPTH_COLORS[depth] || DEPTH_COLORS[1];
-        const id = 'fg-grad-' + depth;
+    function depthGradientId(depth, preRename) {
+        const palette = preRename ? PRERENAME_COLORS : DEPTH_COLORS;
+        const c = palette[depth] || palette[1];
+        const id = (preRename ? 'fg-grad-pre-' : 'fg-grad-') + depth;
         ensureGradient(id, c.base, c.light);
         return id;
     }
@@ -100,9 +101,13 @@ function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onH
             .style('opacity', (animate && !skipAnim) ? 0 : 0.92)
             .merge(rects);
 
-        const gradId = depthGradientId(depth + 1);
-        merged.attr('fill', `url(#${gradId})`).attr('rx', 0).attr('ry', 0).attr('cursor', 'pointer')
-            .attr('stroke', '#3d0000').attr('stroke-width', 1.5);
+        // Fill is per-bar, not per-level: pre-rename callers can sit at the
+        // same depth as live ones and must stay visually distinct.
+        merged.attr('fill', d => `url(#${depthGradientId(depth + 1, d.node.preRename)})`)
+            .attr('rx', 0).attr('ry', 0).attr('cursor', 'pointer')
+            .attr('stroke', d => (d.node.preRename ? '#1a2352' : '#3d0000'))
+            .attr('stroke-dasharray', d => (d.node.preRename ? '4 2' : null))
+            .attr('stroke-width', 1.5);
 
         if (skipAnim) {
             merged.attr('width', d => d.width).attr('y', y).style('opacity', 0.92);
@@ -119,8 +124,8 @@ function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onH
                 .attr('filter', 'drop-shadow(0 0 8px rgba(255,152,0,0.5)) drop-shadow(0 0 16px rgba(255,80,0,0.25)) brightness(1.12)');
             const n = d.node;
             onHover(n.isIntermediate
-                ? { isIntermediate: true, qualifiedName: n.qualifiedName, depth: n.depth }
-                : { isIntermediate: false, name: n.name, qualifiedName: n.qualifiedName, depth: n.depth },
+                ? { isIntermediate: true, qualifiedName: n.qualifiedName, depth: n.depth, preRename: !!n.preRename }
+                : { isIntermediate: false, name: n.name, qualifiedName: n.qualifiedName, depth: n.depth, preRename: !!n.preRename },
                 event.clientX + 14, event.clientY - 10);
             if (onHoverCaller && n.qualifiedName) onHoverCaller(n.qualifiedName);
         })
@@ -173,7 +178,7 @@ function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onH
 
 export async function createFlameGraph() {
     const { html, useState, useRef, useEffect } = await waitForPreact();
-    function FlameGraph({ symbol, width, height, hoveredCaller, onHoverCaller }) {
+    function FlameGraph({ symbol, view, width, height, hoveredCaller, onHoverCaller }) {
         const svgRef = useRef(null); const tooltipRef = useRef(null);
         const [d3Ready, setD3Ready] = useState(typeof window.d3 !== 'undefined');
         const [hover, setHover] = useState(null);
@@ -194,7 +199,7 @@ export async function createFlameGraph() {
             const timers = [];
             const t = setTimeout(() => {
                 if (!el) return;
-                const expected = renderFlameGraph(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, false);
+                const expected = renderFlameGraph(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, false, view);
                 // See the matching verification+repair comment in
                 // SunburstChart.js - same stalled-transition failure mode,
                 // same fix.
@@ -202,13 +207,13 @@ export async function createFlameGraph() {
                 timers.push(setTimeout(() => {
                     if (!el || !el.isConnected) return;
                     if (!verifyChartRender(el, 'rect.flame-bar', expected)) {
-                        renderFlameGraph(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, true);
+                        renderFlameGraph(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, true, view);
                     }
                 }, verifyDelay));
             }, 60);
             timers.push(t);
             return () => timers.forEach(clearTimeout);
-        }, [d3Ready, symbol, width, height]);
+        }, [d3Ready, symbol, view, width, height]);
 
         useEffect(() => {
             if (!d3Ready || !svgRef.current) return;
@@ -230,13 +235,13 @@ export async function createFlameGraph() {
             }
         }, [hoveredCaller, d3Ready]);
         if (!symbol || (!symbol.Callers || symbol.Callers.length === 0)) {
-            return html`<div class="viz-container-fg"><div class="viz-empty">${symbol && symbol.Method === 'text-references' ? 'Text reference method — no call graph available' : 'No callers in the dependency graph'}</div></div>`;
+            return html`<div class="viz-container-fg"><div class="viz-empty">${emptyCallGraphMessage(symbol, view)}</div></div>`;
         }
         return html`
             <div class="viz-container-fg">
                 ${hover && html`
                     <div ref=${tooltipRef} class="viz-tooltip" style="left:${hover.x}px;top:${hover.y}px">
-                        ${renderHoverTooltip(html, hover)}
+                        ${renderHoverTooltip(html, hover, symbol.RenamedFrom)}
                     </div>
                 `}
                 <svg ref=${svgRef} width=${width} height=${height}></svg>

--- a/internal/staticserve/static/components/FlameGraph.js
+++ b/internal/staticserve/static/components/FlameGraph.js
@@ -1,5 +1,5 @@
 import { waitForPreact } from './utils.js';
-import { buildHierarchy, DEPTH_COLORS, PRERENAME_COLORS, renderHoverTooltip, emptyCallGraphMessage, loadD3, verifyChartRender } from './callgraph-utils.js';
+import { buildHierarchy, DEPTH_COLORS, renderHoverTooltip, emptyCallGraphMessage, loadD3, verifyChartRender } from './callgraph-utils.js';
 
 // renderFlameGraph owns d3 rendering only; tooltip content/visibility is
 // reported via onHover(info, x, y) rather than mutated directly on a ref'd
@@ -9,7 +9,7 @@ import { buildHierarchy, DEPTH_COLORS, PRERENAME_COLORS, renderHoverTooltip, emp
 // SunburstChart.js and its use below). immediate=true skips every entrance
 // transition and snaps bars straight to their final width/position/opacity
 // - used for the automatic repair pass after a verification failure.
-function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onHoverCaller, immediate, view) {
+function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onHoverCaller, immediate) {
     const d3 = window.d3;
     const PAD_L = 4;
     const PAD_R = 4;
@@ -26,7 +26,7 @@ function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onH
         svg.append('text').attr('x', width / 2).attr('y', height / 2)
             .attr('text-anchor', 'middle').attr('fill', '#8a7060').attr('font-size', '13px')
             .attr('font-family', '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif')
-            .text(emptyCallGraphMessage(symbol, view));
+            .text(emptyCallGraphMessage(symbol));
         return 0;
     }
 
@@ -57,10 +57,9 @@ function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onH
         grad.append('stop').attr('offset', '0%').attr('stop-color', from).attr('stop-opacity', 1);
         grad.append('stop').attr('offset', '100%').attr('stop-color', to).attr('stop-opacity', 1);
     }
-    function depthGradientId(depth, preRename) {
-        const palette = preRename ? PRERENAME_COLORS : DEPTH_COLORS;
-        const c = palette[depth] || palette[1];
-        const id = (preRename ? 'fg-grad-pre-' : 'fg-grad-') + depth;
+    function depthGradientId(depth) {
+        const c = DEPTH_COLORS[depth] || DEPTH_COLORS[1];
+        const id = 'fg-grad-' + depth;
         ensureGradient(id, c.base, c.light);
         return id;
     }
@@ -101,13 +100,9 @@ function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onH
             .style('opacity', (animate && !skipAnim) ? 0 : 0.92)
             .merge(rects);
 
-        // Fill is per-bar, not per-level: pre-rename callers can sit at the
-        // same depth as live ones and must stay visually distinct.
-        merged.attr('fill', d => `url(#${depthGradientId(depth + 1, d.node.preRename)})`)
-            .attr('rx', 0).attr('ry', 0).attr('cursor', 'pointer')
-            .attr('stroke', d => (d.node.preRename ? '#1a2352' : '#3d0000'))
-            .attr('stroke-dasharray', d => (d.node.preRename ? '4 2' : null))
-            .attr('stroke-width', 1.5);
+        const gradId = depthGradientId(depth + 1);
+        merged.attr('fill', `url(#${gradId})`).attr('rx', 0).attr('ry', 0).attr('cursor', 'pointer')
+            .attr('stroke', '#3d0000').attr('stroke-width', 1.5);
 
         if (skipAnim) {
             merged.attr('width', d => d.width).attr('y', y).style('opacity', 0.92);
@@ -124,8 +119,8 @@ function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onH
                 .attr('filter', 'drop-shadow(0 0 8px rgba(255,152,0,0.5)) drop-shadow(0 0 16px rgba(255,80,0,0.25)) brightness(1.12)');
             const n = d.node;
             onHover(n.isIntermediate
-                ? { isIntermediate: true, qualifiedName: n.qualifiedName, depth: n.depth, preRename: !!n.preRename }
-                : { isIntermediate: false, name: n.name, qualifiedName: n.qualifiedName, depth: n.depth, preRename: !!n.preRename },
+                ? { isIntermediate: true, qualifiedName: n.qualifiedName, depth: n.depth }
+                : { isIntermediate: false, name: n.name, qualifiedName: n.qualifiedName, depth: n.depth },
                 event.clientX + 14, event.clientY - 10);
             if (onHoverCaller && n.qualifiedName) onHoverCaller(n.qualifiedName);
         })
@@ -178,7 +173,7 @@ function renderFlameGraph(svgEl, symbol, width, height, tooltipRef, onHover, onH
 
 export async function createFlameGraph() {
     const { html, useState, useRef, useEffect } = await waitForPreact();
-    function FlameGraph({ symbol, view, width, height, hoveredCaller, onHoverCaller }) {
+    function FlameGraph({ symbol, width, height, hoveredCaller, onHoverCaller }) {
         const svgRef = useRef(null); const tooltipRef = useRef(null);
         const [d3Ready, setD3Ready] = useState(typeof window.d3 !== 'undefined');
         const [hover, setHover] = useState(null);
@@ -199,7 +194,7 @@ export async function createFlameGraph() {
             const timers = [];
             const t = setTimeout(() => {
                 if (!el) return;
-                const expected = renderFlameGraph(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, false, view);
+                const expected = renderFlameGraph(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, false);
                 // See the matching verification+repair comment in
                 // SunburstChart.js - same stalled-transition failure mode,
                 // same fix.
@@ -207,13 +202,13 @@ export async function createFlameGraph() {
                 timers.push(setTimeout(() => {
                     if (!el || !el.isConnected) return;
                     if (!verifyChartRender(el, 'rect.flame-bar', expected)) {
-                        renderFlameGraph(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, true, view);
+                        renderFlameGraph(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, true);
                     }
                 }, verifyDelay));
             }, 60);
             timers.push(t);
             return () => timers.forEach(clearTimeout);
-        }, [d3Ready, symbol, view, width, height]);
+        }, [d3Ready, symbol, width, height]);
 
         useEffect(() => {
             if (!d3Ready || !svgRef.current) return;
@@ -235,13 +230,13 @@ export async function createFlameGraph() {
             }
         }, [hoveredCaller, d3Ready]);
         if (!symbol || (!symbol.Callers || symbol.Callers.length === 0)) {
-            return html`<div class="viz-container-fg"><div class="viz-empty">${emptyCallGraphMessage(symbol, view)}</div></div>`;
+            return html`<div class="viz-container-fg"><div class="viz-empty">${emptyCallGraphMessage(symbol)}</div></div>`;
         }
         return html`
             <div class="viz-container-fg">
                 ${hover && html`
                     <div ref=${tooltipRef} class="viz-tooltip" style="left:${hover.x}px;top:${hover.y}px">
-                        ${renderHoverTooltip(html, hover, symbol.RenamedFrom)}
+                        ${renderHoverTooltip(html, hover)}
                     </div>
                 `}
                 <svg ref=${svgRef} width=${width} height=${height}></svg>

--- a/internal/staticserve/static/components/SunburstChart.js
+++ b/internal/staticserve/static/components/SunburstChart.js
@@ -1,5 +1,5 @@
 import { waitForPreact } from './utils.js';
-import { buildHierarchy, getDepthColor, DEPTH_COLORS, hoverInfoFromDatum, renderHoverTooltip, loadD3, verifyChartRender } from './callgraph-utils.js';
+import { buildHierarchy, getDepthColor, DEPTH_COLORS, PRERENAME_COLORS, hoverInfoFromDatum, renderHoverTooltip, emptyCallGraphMessage, loadD3, verifyChartRender } from './callgraph-utils.js';
 
 function arcTween(a, arcGen) {
     const i = window.d3.interpolate({ x0: a.x0, x1: a.x0 }, a);
@@ -27,7 +27,7 @@ function arcTween(a, arcGen) {
 // failure, so the retry can't itself get caught by whatever stalled the
 // first attempt (a slow/backgrounded tab throttling the transition's timer
 // ticks, concurrent chart mounts competing for the main thread, etc).
-function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHoverCaller, immediate) {
+function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHoverCaller, immediate, view) {
     const d3 = window.d3;
     const radius = Math.min(width, height) / 2;
 
@@ -39,16 +39,18 @@ function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHov
         .style('background', 'transparent');
 
     const defs = svg.append('defs');
-    for (let d = 1; d <= 4; d++) {
-        const c = DEPTH_COLORS[d];
-        if (!c) continue;
+    const addGradient = (id, c) => {
         const grad = defs.append('linearGradient')
-            .attr('id', `sb-grad-${d}`)
+            .attr('id', id)
             .attr('x1', '0').attr('y1', '1')
             .attr('x2', '0').attr('y2', '0');
         grad.append('stop').attr('offset', '0%').attr('stop-color', c.base).attr('stop-opacity', 1);
         grad.append('stop').attr('offset', '60%').attr('stop-color', c.light).attr('stop-opacity', 0.95);
         grad.append('stop').attr('offset', '100%').attr('stop-color', c.light).attr('stop-opacity', 0.7);
+    };
+    for (let d = 1; d <= 4; d++) {
+        if (DEPTH_COLORS[d]) addGradient(`sb-grad-${d}`, DEPTH_COLORS[d]);
+        if (PRERENAME_COLORS[d]) addGradient(`sb-grad-pre-${d}`, PRERENAME_COLORS[d]);
     }
 
     const g = svg.append('g')
@@ -58,7 +60,7 @@ function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHov
         g.append('text').attr('text-anchor', 'middle').attr('dy', '0.35em')
             .attr('fill', '#8a7060').attr('font-size', '13px')
             .attr('font-family', '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif')
-            .text('No callers in the dependency graph');
+            .text(emptyCallGraphMessage(symbol, view));
         return 0;
     }
 
@@ -107,8 +109,9 @@ function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHov
         );
 
     g.selectAll('path.sunburst-arc')
-        .attr('fill', d => `url(#sb-grad-${d.depth})`)
-        .attr('stroke', '#4a0000').attr('stroke-width', 0.7)
+        .attr('fill', d => (d.data.preRename ? `url(#sb-grad-pre-${d.depth})` : `url(#sb-grad-${d.depth})`))
+        .attr('stroke', d => (d.data.preRename ? '#1a2352' : '#4a0000')).attr('stroke-width', 0.7)
+        .attr('stroke-dasharray', d => (d.data.preRename ? '3 2' : null))
         .attr('cursor', 'pointer')
         .on('mouseenter', function (event, d) {
             d3.select(this).interrupt().transition().duration(80)
@@ -129,7 +132,8 @@ function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHov
         .on('mouseleave', function () {
             g.selectAll('path.sunburst-arc').transition().duration(150)
                 .style('opacity', d => (d.data.isLeaf ? 0.92 : 0.78))
-                .attr('stroke', '#4a0000').attr('stroke-width', 0.7).attr('filter', null);
+                .attr('stroke', d => (d.data.preRename ? '#1a2352' : '#4a0000'))
+                .attr('stroke-width', 0.7).attr('filter', null);
             onHover(null);
             if (onHoverCaller) onHoverCaller(null);
         });
@@ -152,7 +156,7 @@ function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHov
 
 export async function createSunburstChart() {
     const { html, useState, useRef, useEffect } = await waitForPreact();
-    function SunburstChart({ symbol, width, height, hoveredCaller, onHoverCaller }) {
+    function SunburstChart({ symbol, view, width, height, hoveredCaller, onHoverCaller }) {
         const svgRef = useRef(null); const tooltipRef = useRef(null);
         const [d3Ready, setD3Ready] = useState(typeof window.d3 !== 'undefined');
         const [hover, setHover] = useState(null);
@@ -175,7 +179,7 @@ export async function createSunburstChart() {
             const timers = [];
             const t = setTimeout(() => {
                 if (!el) return;
-                const expected = renderSunburst(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, false);
+                const expected = renderSunburst(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, false, view);
                 // Verify once the entrance transition should have finished
                 // (last arc's delay + its own duration, plus a grace
                 // margin) - if it stalled or got interrupted (backgrounded
@@ -186,13 +190,13 @@ export async function createSunburstChart() {
                 timers.push(setTimeout(() => {
                     if (!el || !el.isConnected) return;
                     if (!verifyChartRender(el, 'path.sunburst-arc', expected)) {
-                        renderSunburst(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, true);
+                        renderSunburst(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, true, view);
                     }
                 }, verifyDelay));
             }, 60);
             timers.push(t);
             return () => timers.forEach(clearTimeout);
-        }, [d3Ready, symbol, width, height]);
+        }, [d3Ready, symbol, view, width, height]);
 
         useEffect(() => {
             if (!d3Ready || !svgRef.current) return;
@@ -212,17 +216,18 @@ export async function createSunburstChart() {
             } else {
                 arcs.interrupt().transition().duration(150)
                     .style('opacity', d => (d && d.data && d.data.isLeaf ? 0.92 : 0.78))
-                    .attr('stroke', '#4a0000').attr('stroke-width', 0.7).attr('filter', null);
+                    .attr('stroke', d => (d && d.data && d.data.preRename ? '#1a2352' : '#4a0000'))
+                    .attr('stroke-width', 0.7).attr('filter', null);
             }
         }, [hoveredCaller, d3Ready]);
         if (!symbol || (!symbol.Callers || symbol.Callers.length === 0)) {
-            return html`<div class="viz-container-sq"><div class="viz-empty">${symbol && symbol.Method === 'text-references' ? 'Text reference method — no call graph available' : 'No callers in the dependency graph'}</div></div>`;
+            return html`<div class="viz-container-sq"><div class="viz-empty">${emptyCallGraphMessage(symbol, view)}</div></div>`;
         }
         return html`
             <div class="viz-container-sq">
                 ${hover && html`
                     <div ref=${tooltipRef} class="viz-tooltip" style="left:${hover.x}px;top:${hover.y}px">
-                        ${renderHoverTooltip(html, hover)}
+                        ${renderHoverTooltip(html, hover, symbol.RenamedFrom)}
                     </div>
                 `}
                 <svg ref=${svgRef} width=${width} height=${height}></svg>

--- a/internal/staticserve/static/components/SunburstChart.js
+++ b/internal/staticserve/static/components/SunburstChart.js
@@ -1,5 +1,5 @@
 import { waitForPreact } from './utils.js';
-import { buildHierarchy, DEPTH_COLORS, PRERENAME_COLORS, hoverInfoFromDatum, renderHoverTooltip, emptyCallGraphMessage, loadD3, verifyChartRender } from './callgraph-utils.js';
+import { buildHierarchy, DEPTH_COLORS, hoverInfoFromDatum, renderHoverTooltip, emptyCallGraphMessage, loadD3, verifyChartRender } from './callgraph-utils.js';
 
 function arcTween(a, arcGen) {
     const i = window.d3.interpolate({ x0: a.x0, x1: a.x0 }, a);
@@ -27,7 +27,7 @@ function arcTween(a, arcGen) {
 // failure, so the retry can't itself get caught by whatever stalled the
 // first attempt (a slow/backgrounded tab throttling the transition's timer
 // ticks, concurrent chart mounts competing for the main thread, etc).
-function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHoverCaller, immediate, view) {
+function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHoverCaller, immediate) {
     const d3 = window.d3;
     const radius = Math.min(width, height) / 2;
 
@@ -39,18 +39,16 @@ function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHov
         .style('background', 'transparent');
 
     const defs = svg.append('defs');
-    const addGradient = (id, c) => {
+    for (let d = 1; d <= 4; d++) {
+        const c = DEPTH_COLORS[d];
+        if (!c) continue;
         const grad = defs.append('linearGradient')
-            .attr('id', id)
+            .attr('id', `sb-grad-${d}`)
             .attr('x1', '0').attr('y1', '1')
             .attr('x2', '0').attr('y2', '0');
         grad.append('stop').attr('offset', '0%').attr('stop-color', c.base).attr('stop-opacity', 1);
         grad.append('stop').attr('offset', '60%').attr('stop-color', c.light).attr('stop-opacity', 0.95);
         grad.append('stop').attr('offset', '100%').attr('stop-color', c.light).attr('stop-opacity', 0.7);
-    };
-    for (let d = 1; d <= 4; d++) {
-        if (DEPTH_COLORS[d]) addGradient(`sb-grad-${d}`, DEPTH_COLORS[d]);
-        if (PRERENAME_COLORS[d]) addGradient(`sb-grad-pre-${d}`, PRERENAME_COLORS[d]);
     }
 
     const g = svg.append('g')
@@ -60,7 +58,7 @@ function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHov
         g.append('text').attr('text-anchor', 'middle').attr('dy', '0.35em')
             .attr('fill', '#8a7060').attr('font-size', '13px')
             .attr('font-family', '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif')
-            .text(emptyCallGraphMessage(symbol, view));
+            .text(emptyCallGraphMessage(symbol));
         return 0;
     }
 
@@ -109,9 +107,8 @@ function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHov
         );
 
     g.selectAll('path.sunburst-arc')
-        .attr('fill', d => (d.data.preRename ? `url(#sb-grad-pre-${d.depth})` : `url(#sb-grad-${d.depth})`))
-        .attr('stroke', d => (d.data.preRename ? '#1a2352' : '#4a0000')).attr('stroke-width', 0.7)
-        .attr('stroke-dasharray', d => (d.data.preRename ? '3 2' : null))
+        .attr('fill', d => `url(#sb-grad-${d.depth})`)
+        .attr('stroke', '#4a0000').attr('stroke-width', 0.7)
         .attr('cursor', 'pointer')
         .on('mouseenter', function (event, d) {
             d3.select(this).interrupt().transition().duration(80)
@@ -132,8 +129,7 @@ function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHov
         .on('mouseleave', function () {
             g.selectAll('path.sunburst-arc').transition().duration(150)
                 .style('opacity', d => (d.data.isLeaf ? 0.92 : 0.78))
-                .attr('stroke', d => (d.data.preRename ? '#1a2352' : '#4a0000'))
-                .attr('stroke-width', 0.7).attr('filter', null);
+                .attr('stroke', '#4a0000').attr('stroke-width', 0.7).attr('filter', null);
             onHover(null);
             if (onHoverCaller) onHoverCaller(null);
         });
@@ -156,7 +152,7 @@ function renderSunburst(svgEl, symbol, width, height, tooltipRef, onHover, onHov
 
 export async function createSunburstChart() {
     const { html, useState, useRef, useEffect } = await waitForPreact();
-    function SunburstChart({ symbol, view, width, height, hoveredCaller, onHoverCaller }) {
+    function SunburstChart({ symbol, width, height, hoveredCaller, onHoverCaller }) {
         const svgRef = useRef(null); const tooltipRef = useRef(null);
         const [d3Ready, setD3Ready] = useState(typeof window.d3 !== 'undefined');
         const [hover, setHover] = useState(null);
@@ -179,7 +175,7 @@ export async function createSunburstChart() {
             const timers = [];
             const t = setTimeout(() => {
                 if (!el) return;
-                const expected = renderSunburst(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, false, view);
+                const expected = renderSunburst(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, false);
                 // Verify once the entrance transition should have finished
                 // (last arc's delay + its own duration, plus a grace
                 // margin) - if it stalled or got interrupted (backgrounded
@@ -190,13 +186,13 @@ export async function createSunburstChart() {
                 timers.push(setTimeout(() => {
                     if (!el || !el.isConnected) return;
                     if (!verifyChartRender(el, 'path.sunburst-arc', expected)) {
-                        renderSunburst(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, true, view);
+                        renderSunburst(el, symbol, width, height, tooltipRef, onHoverCb, onHoverCaller, true);
                     }
                 }, verifyDelay));
             }, 60);
             timers.push(t);
             return () => timers.forEach(clearTimeout);
-        }, [d3Ready, symbol, view, width, height]);
+        }, [d3Ready, symbol, width, height]);
 
         useEffect(() => {
             if (!d3Ready || !svgRef.current) return;
@@ -216,18 +212,17 @@ export async function createSunburstChart() {
             } else {
                 arcs.interrupt().transition().duration(150)
                     .style('opacity', d => (d && d.data && d.data.isLeaf ? 0.92 : 0.78))
-                    .attr('stroke', d => (d && d.data && d.data.preRename ? '#1a2352' : '#4a0000'))
-                    .attr('stroke-width', 0.7).attr('filter', null);
+                    .attr('stroke', '#4a0000').attr('stroke-width', 0.7).attr('filter', null);
             }
         }, [hoveredCaller, d3Ready]);
         if (!symbol || (!symbol.Callers || symbol.Callers.length === 0)) {
-            return html`<div class="viz-container-sq"><div class="viz-empty">${emptyCallGraphMessage(symbol, view)}</div></div>`;
+            return html`<div class="viz-container-sq"><div class="viz-empty">${emptyCallGraphMessage(symbol)}</div></div>`;
         }
         return html`
             <div class="viz-container-sq">
                 ${hover && html`
                     <div ref=${tooltipRef} class="viz-tooltip" style="left:${hover.x}px;top:${hover.y}px">
-                        ${renderHoverTooltip(html, hover, symbol.RenamedFrom)}
+                        ${renderHoverTooltip(html, hover)}
                     </div>
                 `}
                 <svg ref=${svgRef} width=${width} height=${height}></svg>

--- a/internal/staticserve/static/components/SunburstChart.js
+++ b/internal/staticserve/static/components/SunburstChart.js
@@ -1,5 +1,5 @@
 import { waitForPreact } from './utils.js';
-import { buildHierarchy, getDepthColor, DEPTH_COLORS, PRERENAME_COLORS, hoverInfoFromDatum, renderHoverTooltip, emptyCallGraphMessage, loadD3, verifyChartRender } from './callgraph-utils.js';
+import { buildHierarchy, DEPTH_COLORS, PRERENAME_COLORS, hoverInfoFromDatum, renderHoverTooltip, emptyCallGraphMessage, loadD3, verifyChartRender } from './callgraph-utils.js';
 
 function arcTween(a, arcGen) {
     const i = window.d3.interpolate({ x0: a.x0, x1: a.x0 }, a);

--- a/internal/staticserve/static/components/callgraph-utils.js
+++ b/internal/staticserve/static/components/callgraph-utils.js
@@ -41,80 +41,16 @@ export function verifyChartRender(svgEl, selector, expectedCount) {
     return true;
 }
 
-export function shortName(qualifiedName) {
-    const parts = (qualifiedName || '').split('.');
-    return parts[parts.length - 1] || qualifiedName;
-}
-
-export function buildHierarchy(symbol) {
-    const callers = symbol.Callers || [];
-    const nodeMap = new Map();
-    const children = [];
-    const childrenNames = new Set();
-
-    function ensureNode(qualifiedName, isIntermediate) {
-        if (!nodeMap.has(qualifiedName)) {
-            const node = {
-                name: shortName(qualifiedName),
-                qualifiedName: qualifiedName,
-                children: [],
-                _names: new Set(),
-            };
-            if (isIntermediate) node.isIntermediate = true;
-            nodeMap.set(qualifiedName, node);
-            return node;
-        }
-        return nodeMap.get(qualifiedName);
-    }
-
-    for (const caller of callers) {
-        const path = caller.Path || [];
-
-        if (path.length === 0) {
-            const node = ensureNode(caller.QualifiedName, false);
-            node.depth = caller.Depth;
-            node.weight = caller.Weight;
-            node.isLeaf = true;
-            children.push(node);
-            childrenNames.add(caller.QualifiedName);
-            continue;
-        }
-
-        const firstVia = path[0];
-        const viaNode = ensureNode(firstVia, true);
-        if (!childrenNames.has(firstVia)) {
-            children.push(viaNode);
-            childrenNames.add(firstVia);
-        }
-        if (!viaNode.depth) viaNode.depth = 1;
-
-        let parent = viaNode;
-        for (let i = 1; i < path.length; i++) {
-            const childNode = ensureNode(path[i], true);
-            if (!parent._names.has(path[i])) {
-                parent.children.push(childNode);
-                parent._names.add(path[i]);
-            }
-            if (!childNode.depth) childNode.depth = i + 1;
-            parent = childNode;
-        }
-
-        const leafNode = ensureNode(caller.QualifiedName, false);
-        leafNode.depth = caller.Depth;
-        leafNode.weight = caller.Weight;
-        leafNode.isLeaf = true;
-        if (!parent._names.has(caller.QualifiedName)) {
-            parent.children.push(leafNode);
-            parent._names.add(caller.QualifiedName);
-        }
-    }
-
-    return {
-        name: symbol.Name || shortName(symbol.QualifiedName),
-        qualifiedName: symbol.QualifiedName,
-        children,
-    };
-}
+// The pure half of this module lives in callgraph_model.mjs so it can be unit
+// tested under `node --test`; re-exported here so chart components keep a
+// single import site.
+export {
+    shortName,
+    buildHierarchy,
+    emptyCallGraphMessage,
+    groupCallers,
+    callerGroupLabel,
+} from './callgraph_model.mjs';
 
 export const DEPTH_COLORS = {
     0: { base: '#990000', light: '#e60000' },
@@ -137,7 +73,21 @@ export function interpolateColor(c1, c2, t) {
     return `rgb(${r},${g},${b})`;
 }
 
+// Pre-rename callers reference a name that no longer exists, so they read as
+// broken rather than merely "far away" - a cool, desaturated ramp keeps them
+// visually separate from the warm depth ramp of a live call graph.
+export const PRERENAME_COLORS = {
+    1: { base: '#5c6bc0', light: '#9fa8da' },
+    2: { base: '#7986cb', light: '#c5cae9' },
+    3: { base: '#9575cd', light: '#d1c4e9' },
+    4: { base: '#b39ddb', light: '#ede7f6' },
+};
+
 export function getDepthColor(d) {
+    if (d.data && d.data.preRename) {
+        const ring = PRERENAME_COLORS[d.depth] || { base: '#7986cb' };
+        return ring.base;
+    }
     if (d.depth === 0) return (DEPTH_COLORS[0] || { base: '#12121c' }).base;
     const ring = DEPTH_COLORS[d.depth] || { base: '#607d8b', light: '#90a4ae' };
     if (d.parent && d.parent.children && d.parent.children.length > 1) {
@@ -162,19 +112,31 @@ export function countLeaves(node) {
 export function hoverInfoFromDatum(d) {
     const b = d.data;
     if (b.isIntermediate) {
-        return { isIntermediate: true, qualifiedName: b.qualifiedName, depth: d.depth };
+        return { isIntermediate: true, qualifiedName: b.qualifiedName, depth: d.depth, preRename: !!b.preRename };
     }
-    return { isIntermediate: false, name: b.name, qualifiedName: b.qualifiedName, depth: b.depth };
+    return { isIntermediate: false, name: b.name, qualifiedName: b.qualifiedName, depth: b.depth, preRename: !!b.preRename };
 }
 
 // renderHoverTooltip returns the vdom content for a hover-state object (see
 // hoverInfoFromDatum) - `html` is the caller's own htm-bound tag (each
 // component gets its own instance from waitForPreact(), so it's passed in
 // rather than imported here).
-export function renderHoverTooltip(html, hover) {
+// htm does not decode HTML entities in template text, so these use literal
+// characters ("·", "↳") rather than &middot;/&#8627; - an entity here renders
+// verbatim in the tooltip.
+//
+// oldName is the symbol's pre-rename name, used only to say which name a
+// pre-rename node was found under. The wording stops at what was actually
+// measured (a textual occurrence of that name); it deliberately does not
+// claim the reference is broken, since a grep hit can equally be a comment or
+// a string literal.
+export function renderHoverTooltip(html, hover, oldName) {
     if (!hover) return null;
+    const foundUnder = hover.preRename
+        ? html`<br /><span style="color:#9fa8da;font-size:10px">${oldName ? `still uses the old name "${oldName}"` : 'still uses the old name'}</span>`
+        : null;
     if (hover.isIntermediate) {
-        return html`<strong>&#8627;</strong> ${hover.qualifiedName}<br /><span style="color:#9a8070;font-size:10px">intermediate &middot; depth ${hover.depth}</span>`;
+        return html`<strong>↳</strong> ${hover.qualifiedName}<br /><span style="color:#9a8070;font-size:10px">intermediate · depth ${hover.depth}</span>${foundUnder}`;
     }
-    return html`<strong>${hover.name}</strong><br /><span style="color:#baa090;font-size:10px">${hover.qualifiedName}</span><br /><span style="color:#8a7060;font-size:10px">${hover.depth === 1 ? 'Direct caller' : hover.depth + ' hops away'}</span>`;
+    return html`<strong>${hover.name}</strong><br /><span style="color:#baa090;font-size:10px">${hover.qualifiedName}</span><br /><span style="color:#8a7060;font-size:10px">${hover.depth === 1 ? 'Direct caller' : hover.depth + ' hops away'}</span>${foundUnder}`;
 }

--- a/internal/staticserve/static/components/callgraph-utils.js
+++ b/internal/staticserve/static/components/callgraph-utils.js
@@ -73,21 +73,7 @@ export function interpolateColor(c1, c2, t) {
     return `rgb(${r},${g},${b})`;
 }
 
-// Pre-rename callers reference a name that no longer exists, so they read as
-// broken rather than merely "far away" - a cool, desaturated ramp keeps them
-// visually separate from the warm depth ramp of a live call graph.
-export const PRERENAME_COLORS = {
-    1: { base: '#5c6bc0', light: '#9fa8da' },
-    2: { base: '#7986cb', light: '#c5cae9' },
-    3: { base: '#9575cd', light: '#d1c4e9' },
-    4: { base: '#b39ddb', light: '#ede7f6' },
-};
-
 export function getDepthColor(d) {
-    if (d.data && d.data.preRename) {
-        const ring = PRERENAME_COLORS[d.depth] || { base: '#7986cb' };
-        return ring.base;
-    }
     if (d.depth === 0) return (DEPTH_COLORS[0] || { base: '#12121c' }).base;
     const ring = DEPTH_COLORS[d.depth] || { base: '#607d8b', light: '#90a4ae' };
     if (d.parent && d.parent.children && d.parent.children.length > 1) {
@@ -112,31 +98,23 @@ export function countLeaves(node) {
 export function hoverInfoFromDatum(d) {
     const b = d.data;
     if (b.isIntermediate) {
-        return { isIntermediate: true, qualifiedName: b.qualifiedName, depth: d.depth, preRename: !!b.preRename };
+        return { isIntermediate: true, qualifiedName: b.qualifiedName, depth: d.depth };
     }
-    return { isIntermediate: false, name: b.name, qualifiedName: b.qualifiedName, depth: b.depth, preRename: !!b.preRename };
+    return { isIntermediate: false, name: b.name, qualifiedName: b.qualifiedName, depth: b.depth };
 }
 
 // renderHoverTooltip returns the vdom content for a hover-state object (see
 // hoverInfoFromDatum) - `html` is the caller's own htm-bound tag (each
 // component gets its own instance from waitForPreact(), so it's passed in
 // rather than imported here).
-// htm does not decode HTML entities in template text, so these use literal
-// characters ("·", "↳") rather than &middot;/&#8627; - an entity here renders
-// verbatim in the tooltip.
 //
-// oldName is the symbol's pre-rename name, used only to say which name a
-// pre-rename node was found under. The wording stops at what was actually
-// measured (a textual occurrence of that name); it deliberately does not
-// claim the reference is broken, since a grep hit can equally be a comment or
-// a string literal.
-export function renderHoverTooltip(html, hover, oldName) {
+// htm does not decode HTML entities in template text, so this uses literal
+// characters ("·", "↳") rather than &middot;/&#8627; - an entity here would
+// render verbatim in the tooltip instead of the symbol it names.
+export function renderHoverTooltip(html, hover) {
     if (!hover) return null;
-    const foundUnder = hover.preRename
-        ? html`<br /><span style="color:#9fa8da;font-size:10px">${oldName ? `still uses the old name "${oldName}"` : 'still uses the old name'}</span>`
-        : null;
     if (hover.isIntermediate) {
-        return html`<strong>↳</strong> ${hover.qualifiedName}<br /><span style="color:#9a8070;font-size:10px">intermediate · depth ${hover.depth}</span>${foundUnder}`;
+        return html`<strong>↳</strong> ${hover.qualifiedName}<br /><span style="color:#9a8070;font-size:10px">intermediate · depth ${hover.depth}</span>`;
     }
-    return html`<strong>${hover.name}</strong><br /><span style="color:#baa090;font-size:10px">${hover.qualifiedName}</span><br /><span style="color:#8a7060;font-size:10px">${hover.depth === 1 ? 'Direct caller' : hover.depth + ' hops away'}</span>${foundUnder}`;
+    return html`<strong>${hover.name}</strong><br /><span style="color:#baa090;font-size:10px">${hover.qualifiedName}</span><br /><span style="color:#8a7060;font-size:10px">${hover.depth === 1 ? 'Direct caller' : hover.depth + ' hops away'}</span>`;
 }

--- a/internal/staticserve/static/components/callgraph_model.mjs
+++ b/internal/staticserve/static/components/callgraph_model.mjs
@@ -1,0 +1,188 @@
+// Pure call-graph presentation logic, kept out of callgraph-utils.js so it
+// can be unit tested under `node --test` (the .js modules in this directory
+// are browser-only ES modules - node treats them as CommonJS, and they reach
+// for window/document/d3). callgraph-utils.js re-exports everything here, so
+// chart components keep importing from a single place.
+
+export function shortName(qualifiedName) {
+    const parts = (qualifiedName || '').split('.');
+    return parts[parts.length - 1] || qualifiedName;
+}
+
+// buildHierarchy turns a symbol's flat caller list into the nested shape both
+// charts render. Callers arrive with a Path of the intermediate nodes between
+// the symbol and themselves (ordered outward from the symbol), so a depth-3
+// caller contributes two intermediate levels plus its own leaf.
+//
+// A caller flagged PreRename references the symbol's *old* name and breaks
+// until it's migrated. That flag propagates to every node on its branch, not
+// just its leaf: an intermediate only reaches the symbol through the broken
+// name, so the whole path is breaking.
+export function buildHierarchy(symbol) {
+    const callers = symbol.Callers || [];
+    const nodeMap = new Map();
+    const children = [];
+    const childrenNames = new Set();
+
+    function ensureNode(qualifiedName, isIntermediate) {
+        if (!nodeMap.has(qualifiedName)) {
+            const node = {
+                name: shortName(qualifiedName),
+                qualifiedName: qualifiedName,
+                children: [],
+                _names: new Set(),
+            };
+            if (isIntermediate) node.isIntermediate = true;
+            nodeMap.set(qualifiedName, node);
+            return node;
+        }
+        return nodeMap.get(qualifiedName);
+    }
+
+    for (const caller of callers) {
+        const path = caller.Path || [];
+
+        if (path.length === 0) {
+            const node = ensureNode(caller.QualifiedName, false);
+            node.depth = caller.Depth;
+            node.weight = caller.Weight;
+            node.isLeaf = true;
+            if (caller.PreRename) node.preRename = true;
+            children.push(node);
+            childrenNames.add(caller.QualifiedName);
+            continue;
+        }
+
+        const firstVia = path[0];
+        const viaNode = ensureNode(firstVia, true);
+        if (!childrenNames.has(firstVia)) {
+            children.push(viaNode);
+            childrenNames.add(firstVia);
+        }
+        if (!viaNode.depth) viaNode.depth = 1;
+        if (caller.PreRename) viaNode.preRename = true;
+
+        let parent = viaNode;
+        for (let i = 1; i < path.length; i++) {
+            const childNode = ensureNode(path[i], true);
+            if (!parent._names.has(path[i])) {
+                parent.children.push(childNode);
+                parent._names.add(path[i]);
+            }
+            if (!childNode.depth) childNode.depth = i + 1;
+            if (caller.PreRename) childNode.preRename = true;
+            parent = childNode;
+        }
+
+        const leafNode = ensureNode(caller.QualifiedName, false);
+        leafNode.depth = caller.Depth;
+        leafNode.weight = caller.Weight;
+        leafNode.isLeaf = true;
+        if (caller.PreRename) leafNode.preRename = true;
+        if (!parent._names.has(caller.QualifiedName)) {
+            parent.children.push(leafNode);
+            parent._names.add(caller.QualifiedName);
+        }
+    }
+
+    return {
+        name: symbol.Name || shortName(symbol.QualifiedName),
+        qualifiedName: symbol.QualifiedName,
+        children,
+    };
+}
+
+// emptyCallGraphMessage explains *why* a symbol has nothing to draw, which is
+// otherwise easy to misread as a broken chart. A renamed symbol is the case
+// worth calling out: its post-rename name genuinely has no callers yet, so a
+// bare "no callers" reads as a leaf function when it actually means nothing
+// else uses the old name either.
+export function emptyCallGraphMessage(symbol, view) {
+    if (symbol && symbol.RenamedFrom) {
+        const newName = symbol.Name || shortName(symbol.QualifiedName);
+        if (view === RENAME_VIEW_AFTER) {
+            return `Nothing calls "${newName}" yet — renamed from "${symbol.RenamedFrom}"`;
+        }
+        if (view === RENAME_VIEW_BEFORE) {
+            return `Nothing else uses the old name "${symbol.RenamedFrom}"`;
+        }
+        return `Renamed from "${symbol.RenamedFrom}" — nothing else uses the old name`;
+    }
+    if (symbol && symbol.Method === 'text-references') {
+        return 'Text reference method — no call graph available';
+    }
+    return 'No callers in the dependency graph';
+}
+
+// A renamed symbol has two genuinely different call graphs, and the index only
+// knows one of them. "After" is the real thing: CALLS fan-in on the new name,
+// as the graph sees the post-change tree - usually empty right after a rename.
+// "Before" is who still uses the old name, recovered by text search because
+// the old name has no node left to walk from. Keeping them as separate views
+// stops the empty After graph from reading as "no callers, nothing to see".
+export const RENAME_VIEW_BEFORE = 'before';
+export const RENAME_VIEW_AFTER = 'after';
+
+// hasRenameViews reports whether the Before/After split is meaningful for this
+// symbol - only renamed symbols have two states to compare.
+export function hasRenameViews(symbol) {
+    return !!(symbol && symbol.RenamedFrom);
+}
+
+// callersForRenameView selects the callers belonging to one side of the split.
+// Symbols that were not renamed have a single graph and ignore view entirely.
+export function callersForRenameView(symbol, view) {
+    const callers = (symbol && symbol.Callers) || [];
+    if (!hasRenameViews(symbol)) return callers;
+    if (view === RENAME_VIEW_BEFORE) return callers.filter((c) => c.PreRename);
+    return callers.filter((c) => !c.PreRename);
+}
+
+// symbolForRenameView returns the symbol as the charts should see it for the
+// selected view - same symbol, Callers narrowed to that side.
+export function symbolForRenameView(symbol, view) {
+    if (!hasRenameViews(symbol)) return symbol;
+    return { ...symbol, Callers: callersForRenameView(symbol, view) };
+}
+
+// groupCallers buckets a caller list for the sidebar. Pre-rename callers get
+// their own bucket ahead of the depth buckets rather than being folded into
+// "Direct callers": they were found under a different name and are the ones
+// worth looking at first, so mixing them into live callers of the same depth
+// loses exactly the distinction that matters.
+export function groupCallers(callers) {
+    const preRename = [];
+    const byDepth = new Map();
+    (callers || []).forEach((c) => {
+        if (c.PreRename) {
+            preRename.push(c);
+            return;
+        }
+        const depth = c.Depth || 1;
+        if (!byDepth.has(depth)) byDepth.set(depth, []);
+        byDepth.get(depth).push(c);
+    });
+
+    const groups = [...byDepth.entries()]
+        .sort((a, b) => a[0] - b[0])
+        .map(([depth, list]) => ({ key: `d${depth}`, depth, preRename: false, callers: list }));
+
+    if (preRename.length > 0) {
+        groups.unshift({ key: 'pre-rename', depth: 1, preRename: true, callers: preRename });
+    }
+    return groups;
+}
+
+// callerGroupLabel names a bucket. The pre-rename label deliberately states
+// only what was measured - a textual occurrence of the old name inside these
+// symbols - and not what it implies. A grep hit can be a real call, a comment,
+// or a string literal, so claiming these "break" asserts a compile failure
+// that was never verified. oldName is the pre-rename name (symbol.RenamedFrom)
+// when known; without it the label stays generic rather than guessing.
+export function callerGroupLabel(group, oldName) {
+    if (group.preRename) {
+        return oldName ? `Still uses the old name "${oldName}"` : 'Still uses the old name';
+    }
+    if (group.depth === 1) return 'Direct callers';
+    return `${group.depth} calls away`;
+}

--- a/internal/staticserve/static/components/callgraph_model.mjs
+++ b/internal/staticserve/static/components/callgraph_model.mjs
@@ -14,10 +14,11 @@ export function shortName(qualifiedName) {
 // the symbol and themselves (ordered outward from the symbol), so a depth-3
 // caller contributes two intermediate levels plus its own leaf.
 //
-// A caller flagged PreRename references the symbol's *old* name and breaks
-// until it's migrated. That flag propagates to every node on its branch, not
-// just its leaf: an intermediate only reaches the symbol through the broken
-// name, so the whole path is breaking.
+// This must only ever see genuine CALLS-graph callers - the chart draws an
+// edge for every entry, so anything synthesized (e.g. a symbol's pre-rename
+// callers, found by text search rather than a real graph edge) would render
+// as a call that was never actually observed. Callers should filter those out
+// before invoking this; see BlastRadiusPanel's chartSymbol.
 export function buildHierarchy(symbol) {
     const callers = symbol.Callers || [];
     const nodeMap = new Map();
@@ -47,7 +48,6 @@ export function buildHierarchy(symbol) {
             node.depth = caller.Depth;
             node.weight = caller.Weight;
             node.isLeaf = true;
-            if (caller.PreRename) node.preRename = true;
             children.push(node);
             childrenNames.add(caller.QualifiedName);
             continue;
@@ -60,7 +60,6 @@ export function buildHierarchy(symbol) {
             childrenNames.add(firstVia);
         }
         if (!viaNode.depth) viaNode.depth = 1;
-        if (caller.PreRename) viaNode.preRename = true;
 
         let parent = viaNode;
         for (let i = 1; i < path.length; i++) {
@@ -70,7 +69,6 @@ export function buildHierarchy(symbol) {
                 parent._names.add(path[i]);
             }
             if (!childNode.depth) childNode.depth = i + 1;
-            if (caller.PreRename) childNode.preRename = true;
             parent = childNode;
         }
 
@@ -78,7 +76,6 @@ export function buildHierarchy(symbol) {
         leafNode.depth = caller.Depth;
         leafNode.weight = caller.Weight;
         leafNode.isLeaf = true;
-        if (caller.PreRename) leafNode.preRename = true;
         if (!parent._names.has(caller.QualifiedName)) {
             parent.children.push(leafNode);
             parent._names.add(caller.QualifiedName);
@@ -92,57 +89,16 @@ export function buildHierarchy(symbol) {
     };
 }
 
-// emptyCallGraphMessage explains *why* a symbol has nothing to draw, which is
-// otherwise easy to misread as a broken chart. A renamed symbol is the case
-// worth calling out: its post-rename name genuinely has no callers yet, so a
-// bare "no callers" reads as a leaf function when it actually means nothing
-// else uses the old name either.
-export function emptyCallGraphMessage(symbol, view) {
-    if (symbol && symbol.RenamedFrom) {
-        const newName = symbol.Name || shortName(symbol.QualifiedName);
-        if (view === RENAME_VIEW_AFTER) {
-            return `Nothing calls "${newName}" yet — renamed from "${symbol.RenamedFrom}"`;
-        }
-        if (view === RENAME_VIEW_BEFORE) {
-            return `Nothing else uses the old name "${symbol.RenamedFrom}"`;
-        }
-        return `Renamed from "${symbol.RenamedFrom}" — nothing else uses the old name`;
-    }
+// emptyCallGraphMessage explains why a symbol has nothing to draw. Kept
+// graph-agnostic to rename status on purpose: the chart only ever sees real
+// CALLS-graph callers (see buildHierarchy), so whether this symbol was
+// renamed is irrelevant to what the *chart* shows - that context belongs in
+// the left column's CallerGroup instead (see groupCallers/callerGroupLabel).
+export function emptyCallGraphMessage(symbol) {
     if (symbol && symbol.Method === 'text-references') {
         return 'Text reference method — no call graph available';
     }
     return 'No callers in the dependency graph';
-}
-
-// A renamed symbol has two genuinely different call graphs, and the index only
-// knows one of them. "After" is the real thing: CALLS fan-in on the new name,
-// as the graph sees the post-change tree - usually empty right after a rename.
-// "Before" is who still uses the old name, recovered by text search because
-// the old name has no node left to walk from. Keeping them as separate views
-// stops the empty After graph from reading as "no callers, nothing to see".
-export const RENAME_VIEW_BEFORE = 'before';
-export const RENAME_VIEW_AFTER = 'after';
-
-// hasRenameViews reports whether the Before/After split is meaningful for this
-// symbol - only renamed symbols have two states to compare.
-export function hasRenameViews(symbol) {
-    return !!(symbol && symbol.RenamedFrom);
-}
-
-// callersForRenameView selects the callers belonging to one side of the split.
-// Symbols that were not renamed have a single graph and ignore view entirely.
-export function callersForRenameView(symbol, view) {
-    const callers = (symbol && symbol.Callers) || [];
-    if (!hasRenameViews(symbol)) return callers;
-    if (view === RENAME_VIEW_BEFORE) return callers.filter((c) => c.PreRename);
-    return callers.filter((c) => !c.PreRename);
-}
-
-// symbolForRenameView returns the symbol as the charts should see it for the
-// selected view - same symbol, Callers narrowed to that side.
-export function symbolForRenameView(symbol, view) {
-    if (!hasRenameViews(symbol)) return symbol;
-    return { ...symbol, Callers: callersForRenameView(symbol, view) };
 }
 
 // groupCallers buckets a caller list for the sidebar. Pre-rename callers get

--- a/internal/staticserve/static/components/callgraph_model.test.mjs
+++ b/internal/staticserve/static/components/callgraph_model.test.mjs
@@ -1,0 +1,200 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    buildHierarchy,
+    callerGroupLabel,
+    callersForRenameView,
+    emptyCallGraphMessage,
+    groupCallers,
+    hasRenameViews,
+    RENAME_VIEW_AFTER,
+    RENAME_VIEW_BEFORE,
+    shortName,
+    symbolForRenameView,
+} from './callgraph_model.mjs';
+
+const RENAMED = {
+    Name: 'RuHelp',
+    QualifiedName: 'pkg.RuHelp',
+    RenamedFrom: 'RunHelp',
+    Callers: [
+        { QualifiedName: 'pkg.main', Depth: 1, PreRename: true },
+        { QualifiedName: 'pkg.migrated', Depth: 1 },
+    ],
+};
+
+test('shortName takes the last dotted segment', () => {
+    assert.equal(shortName('a.b.c.RunHelp'), 'RunHelp');
+    assert.equal(shortName('RunHelp'), 'RunHelp');
+    assert.equal(shortName(''), '');
+});
+
+test('buildHierarchy nests callers by their Path', () => {
+    const root = buildHierarchy({
+        Name: 'leftWidth',
+        QualifiedName: 'pkg.leftWidth',
+        Callers: [
+            { QualifiedName: 'pkg.renderFileList', Depth: 1, Weight: 1 },
+            { QualifiedName: 'pkg.View', Depth: 2, Weight: 0.5, Path: ['pkg.renderFileList'] },
+        ],
+    });
+
+    assert.equal(root.name, 'leftWidth');
+    assert.equal(root.children.length, 1, 'the depth-2 caller reuses its via node, not a second child');
+    const via = root.children[0];
+    assert.equal(via.qualifiedName, 'pkg.renderFileList');
+    assert.equal(via.children.length, 1);
+    assert.equal(via.children[0].qualifiedName, 'pkg.View');
+    assert.equal(via.children[0].depth, 2);
+});
+
+test('buildHierarchy marks pre-rename callers', () => {
+    const root = buildHierarchy({
+        Name: 'RuHelp',
+        QualifiedName: 'pkg.RuHelp',
+        Callers: [{ QualifiedName: 'pkg.main', Depth: 1, Weight: 1, PreRename: true }],
+    });
+
+    assert.equal(root.children.length, 1);
+    assert.equal(root.children[0].qualifiedName, 'pkg.main');
+    assert.equal(root.children[0].preRename, true);
+});
+
+test('buildHierarchy propagates preRename across a whole branch', () => {
+    // An intermediate only reaches the renamed symbol through the broken
+    // name, so it is breaking too - not just the leaf at the end.
+    const root = buildHierarchy({
+        Name: 'RuHelp',
+        QualifiedName: 'pkg.RuHelp',
+        Callers: [
+            { QualifiedName: 'pkg.direct', Depth: 1, Weight: 1, PreRename: true },
+            { QualifiedName: 'pkg.top', Depth: 2, Weight: 0.5, Path: ['pkg.direct'], PreRename: true },
+        ],
+    });
+
+    const via = root.children[0];
+    assert.equal(via.preRename, true, 'intermediate must inherit the breaking flag');
+    assert.equal(via.children[0].preRename, true);
+});
+
+test('buildHierarchy leaves live callers unflagged', () => {
+    const root = buildHierarchy({
+        QualifiedName: 'pkg.leftWidth',
+        Callers: [{ QualifiedName: 'pkg.renderPreview', Depth: 1, Weight: 1 }],
+    });
+    assert.equal(root.children[0].preRename, undefined);
+});
+
+test('groupCallers puts pre-rename callers in their own leading group', () => {
+    const groups = groupCallers([
+        { QualifiedName: 'pkg.liveA', Depth: 1 },
+        { QualifiedName: 'pkg.broken', Depth: 1, PreRename: true },
+        { QualifiedName: 'pkg.liveB', Depth: 2 },
+    ]);
+
+    assert.equal(groups.length, 3);
+    assert.equal(groups[0].key, 'pre-rename', 'breaking callers lead - they are the actionable ones');
+    assert.deepEqual(groups[0].callers.map((c) => c.QualifiedName), ['pkg.broken']);
+    assert.equal(groups[1].depth, 1);
+    assert.deepEqual(groups[1].callers.map((c) => c.QualifiedName), ['pkg.liveA']);
+    assert.equal(groups[2].depth, 2);
+});
+
+test('groupCallers keeps depth ordering when nothing is pre-rename', () => {
+    const groups = groupCallers([
+        { QualifiedName: 'pkg.c', Depth: 3 },
+        { QualifiedName: 'pkg.a', Depth: 1 },
+        { QualifiedName: 'pkg.b', Depth: 2 },
+    ]);
+    assert.deepEqual(groups.map((g) => g.depth), [1, 2, 3]);
+    assert.ok(groups.every((g) => g.preRename === false));
+});
+
+test('groupCallers handles empty input', () => {
+    assert.deepEqual(groupCallers(null), []);
+    assert.deepEqual(groupCallers([]), []);
+});
+
+test('callerGroupLabel names each bucket', () => {
+    assert.equal(callerGroupLabel({ preRename: true, depth: 1 }, 'RunHelp'), 'Still uses the old name "RunHelp"');
+    assert.equal(callerGroupLabel({ preRename: false, depth: 1 }), 'Direct callers');
+    assert.equal(callerGroupLabel({ preRename: false, depth: 3 }), '3 calls away');
+});
+
+test('callerGroupLabel stays generic without an old name', () => {
+    assert.equal(callerGroupLabel({ preRename: true, depth: 1 }), 'Still uses the old name');
+});
+
+test('callerGroupLabel claims only what was measured', () => {
+    // A grep hit for the old name can be a real call, a comment, or a string
+    // literal - the label must not assert breakage we never verified.
+    const label = callerGroupLabel({ preRename: true, depth: 1 }, 'RunHelp');
+    assert.doesNotMatch(label, /break/i);
+});
+
+test('emptyCallGraphMessage explains a fully-migrated rename', () => {
+    assert.equal(
+        emptyCallGraphMessage({ RenamedFrom: 'RunHelp', Method: 'calls' }),
+        'Renamed from "RunHelp" — nothing else uses the old name',
+    );
+});
+
+test('emptyCallGraphMessage falls back to method and generic copy', () => {
+    assert.equal(
+        emptyCallGraphMessage({ Method: 'text-references' }),
+        'Text reference method — no call graph available',
+    );
+    assert.equal(emptyCallGraphMessage({ Method: 'calls' }), 'No callers in the dependency graph');
+    assert.equal(emptyCallGraphMessage(null), 'No callers in the dependency graph');
+});
+
+test('emptyCallGraphMessage is view-specific for a renamed symbol', () => {
+    assert.equal(
+        emptyCallGraphMessage(RENAMED, RENAME_VIEW_AFTER),
+        'Nothing calls "RuHelp" yet — renamed from "RunHelp"',
+    );
+    assert.equal(
+        emptyCallGraphMessage(RENAMED, RENAME_VIEW_BEFORE),
+        'Nothing else uses the old name "RunHelp"',
+    );
+});
+
+test('hasRenameViews is true only for renamed symbols', () => {
+    assert.equal(hasRenameViews(RENAMED), true);
+    assert.equal(hasRenameViews({ QualifiedName: 'pkg.leftWidth', Callers: [] }), false);
+    assert.equal(hasRenameViews(null), false);
+});
+
+test('callersForRenameView splits the two graphs', () => {
+    assert.deepEqual(
+        callersForRenameView(RENAMED, RENAME_VIEW_BEFORE).map((c) => c.QualifiedName),
+        ['pkg.main'],
+    );
+    assert.deepEqual(
+        callersForRenameView(RENAMED, RENAME_VIEW_AFTER).map((c) => c.QualifiedName),
+        ['pkg.migrated'],
+    );
+});
+
+test('callersForRenameView ignores the view for unrenamed symbols', () => {
+    // A symbol that was not renamed has one graph, not two - the view must
+    // not silently filter its callers away.
+    const plain = { QualifiedName: 'pkg.leftWidth', Callers: [{ QualifiedName: 'pkg.a', Depth: 1 }] };
+    assert.equal(callersForRenameView(plain, RENAME_VIEW_BEFORE).length, 1);
+    assert.equal(callersForRenameView(plain, RENAME_VIEW_AFTER).length, 1);
+});
+
+test('symbolForRenameView narrows Callers but keeps identity fields', () => {
+    const before = symbolForRenameView(RENAMED, RENAME_VIEW_BEFORE);
+    assert.equal(before.QualifiedName, 'pkg.RuHelp');
+    assert.equal(before.RenamedFrom, 'RunHelp');
+    assert.deepEqual(before.Callers.map((c) => c.QualifiedName), ['pkg.main']);
+});
+
+test('symbolForRenameView returns unrenamed symbols unchanged by identity', () => {
+    // Charts key their render effect on symbol identity; returning a fresh
+    // object for every unrenamed symbol would redraw on each parent render.
+    const plain = { QualifiedName: 'pkg.leftWidth', Callers: [] };
+    assert.equal(symbolForRenameView(plain, RENAME_VIEW_AFTER), plain);
+});

--- a/internal/staticserve/static/components/callgraph_model.test.mjs
+++ b/internal/staticserve/static/components/callgraph_model.test.mjs
@@ -4,25 +4,10 @@ import assert from 'node:assert/strict';
 import {
     buildHierarchy,
     callerGroupLabel,
-    callersForRenameView,
     emptyCallGraphMessage,
     groupCallers,
-    hasRenameViews,
-    RENAME_VIEW_AFTER,
-    RENAME_VIEW_BEFORE,
     shortName,
-    symbolForRenameView,
 } from './callgraph_model.mjs';
-
-const RENAMED = {
-    Name: 'RuHelp',
-    QualifiedName: 'pkg.RuHelp',
-    RenamedFrom: 'RunHelp',
-    Callers: [
-        { QualifiedName: 'pkg.main', Depth: 1, PreRename: true },
-        { QualifiedName: 'pkg.migrated', Depth: 1 },
-    ],
-};
 
 test('shortName takes the last dotted segment', () => {
     assert.equal(shortName('a.b.c.RunHelp'), 'RunHelp');
@@ -49,36 +34,12 @@ test('buildHierarchy nests callers by their Path', () => {
     assert.equal(via.children[0].depth, 2);
 });
 
-test('buildHierarchy marks pre-rename callers', () => {
-    const root = buildHierarchy({
-        Name: 'RuHelp',
-        QualifiedName: 'pkg.RuHelp',
-        Callers: [{ QualifiedName: 'pkg.main', Depth: 1, Weight: 1, PreRename: true }],
-    });
-
-    assert.equal(root.children.length, 1);
-    assert.equal(root.children[0].qualifiedName, 'pkg.main');
-    assert.equal(root.children[0].preRename, true);
-});
-
-test('buildHierarchy propagates preRename across a whole branch', () => {
-    // An intermediate only reaches the renamed symbol through the broken
-    // name, so it is breaking too - not just the leaf at the end.
-    const root = buildHierarchy({
-        Name: 'RuHelp',
-        QualifiedName: 'pkg.RuHelp',
-        Callers: [
-            { QualifiedName: 'pkg.direct', Depth: 1, Weight: 1, PreRename: true },
-            { QualifiedName: 'pkg.top', Depth: 2, Weight: 0.5, Path: ['pkg.direct'], PreRename: true },
-        ],
-    });
-
-    const via = root.children[0];
-    assert.equal(via.preRename, true, 'intermediate must inherit the breaking flag');
-    assert.equal(via.children[0].preRename, true);
-});
-
-test('buildHierarchy leaves live callers unflagged', () => {
+test('buildHierarchy ignores PreRename - it must only ever see real graph callers', () => {
+    // BlastRadiusPanel's chartSymbol strips PreRename entries before a symbol
+    // ever reaches buildHierarchy, so the flag carries no special meaning
+    // here - a caller is a caller. This pins that buildHierarchy itself does
+    // no rename-aware branching (that logic lives in groupCallers, for the
+    // left column only).
     const root = buildHierarchy({
         QualifiedName: 'pkg.leftWidth',
         Callers: [{ QualifiedName: 'pkg.renderPreview', Depth: 1, Weight: 1 }],
@@ -133,10 +94,13 @@ test('callerGroupLabel claims only what was measured', () => {
     assert.doesNotMatch(label, /break/i);
 });
 
-test('emptyCallGraphMessage explains a fully-migrated rename', () => {
+test('emptyCallGraphMessage ignores RenamedFrom - the chart is not rename-aware', () => {
+    // Whether a symbol was renamed is a left-column concern (CallerGroup);
+    // the chart's empty state must read identically either way, since it
+    // only ever describes the real CALLS graph, never rename status.
     assert.equal(
         emptyCallGraphMessage({ RenamedFrom: 'RunHelp', Method: 'calls' }),
-        'Renamed from "RunHelp" — nothing else uses the old name',
+        'No callers in the dependency graph',
     );
 });
 
@@ -147,54 +111,4 @@ test('emptyCallGraphMessage falls back to method and generic copy', () => {
     );
     assert.equal(emptyCallGraphMessage({ Method: 'calls' }), 'No callers in the dependency graph');
     assert.equal(emptyCallGraphMessage(null), 'No callers in the dependency graph');
-});
-
-test('emptyCallGraphMessage is view-specific for a renamed symbol', () => {
-    assert.equal(
-        emptyCallGraphMessage(RENAMED, RENAME_VIEW_AFTER),
-        'Nothing calls "RuHelp" yet — renamed from "RunHelp"',
-    );
-    assert.equal(
-        emptyCallGraphMessage(RENAMED, RENAME_VIEW_BEFORE),
-        'Nothing else uses the old name "RunHelp"',
-    );
-});
-
-test('hasRenameViews is true only for renamed symbols', () => {
-    assert.equal(hasRenameViews(RENAMED), true);
-    assert.equal(hasRenameViews({ QualifiedName: 'pkg.leftWidth', Callers: [] }), false);
-    assert.equal(hasRenameViews(null), false);
-});
-
-test('callersForRenameView splits the two graphs', () => {
-    assert.deepEqual(
-        callersForRenameView(RENAMED, RENAME_VIEW_BEFORE).map((c) => c.QualifiedName),
-        ['pkg.main'],
-    );
-    assert.deepEqual(
-        callersForRenameView(RENAMED, RENAME_VIEW_AFTER).map((c) => c.QualifiedName),
-        ['pkg.migrated'],
-    );
-});
-
-test('callersForRenameView ignores the view for unrenamed symbols', () => {
-    // A symbol that was not renamed has one graph, not two - the view must
-    // not silently filter its callers away.
-    const plain = { QualifiedName: 'pkg.leftWidth', Callers: [{ QualifiedName: 'pkg.a', Depth: 1 }] };
-    assert.equal(callersForRenameView(plain, RENAME_VIEW_BEFORE).length, 1);
-    assert.equal(callersForRenameView(plain, RENAME_VIEW_AFTER).length, 1);
-});
-
-test('symbolForRenameView narrows Callers but keeps identity fields', () => {
-    const before = symbolForRenameView(RENAMED, RENAME_VIEW_BEFORE);
-    assert.equal(before.QualifiedName, 'pkg.RuHelp');
-    assert.equal(before.RenamedFrom, 'RunHelp');
-    assert.deepEqual(before.Callers.map((c) => c.QualifiedName), ['pkg.main']);
-});
-
-test('symbolForRenameView returns unrenamed symbols unchanged by identity', () => {
-    // Charts key their render effect on symbol identity; returning a fresh
-    // object for every unrenamed symbol would redraw on each parent render.
-    const plain = { QualifiedName: 'pkg.leftWidth', Callers: [] };
-    assert.equal(symbolForRenameView(plain, RENAME_VIEW_AFTER), plain);
 });

--- a/internal/staticserve/static/styles.css
+++ b/internal/staticserve/static/styles.css
@@ -3238,28 +3238,30 @@ body {
   box-shadow: 0 0 4px rgba(255, 87, 34, 0.2);
 }
 
-/* Pre-rename callers: they reference the symbol's OLD name and break until
-   migrated, so they get the same cool/indigo treatment the charts use for
-   them (PRERENAME_COLORS in callgraph-utils.js) rather than reading as
-   ordinary live callers. */
+/* Pre-rename callers (left column only - see BlastRadiusPanel's
+   chartSymbol): found by text search against the symbol's old name, not a
+   verified CALLS edge, so they get the app's existing red/critical treatment
+   (--accent-red) to read as a flag worth checking, distinct from ordinary
+   live callers. This styling is scoped to the left column's CallerGroup
+   component and never reaches the chart. */
 .blast-caller-group.pre-rename .blast-caller-group-header {
-  color: #9fa8da;
+  color: var(--accent-red);
 }
 .blast-caller-group.pre-rename .blast-caller-count {
-  background: rgba(92, 107, 192, 0.22);
-  color: #c5cae9;
+  background: rgba(241, 76, 76, 0.2);
+  color: var(--accent-red);
 }
 .blast-caller.pre-rename {
-  background: rgba(92, 107, 192, 0.12);
-  border: 1px dashed rgba(159, 168, 218, 0.55);
-  color: #b6bde0;
+  background: rgba(241, 76, 76, 0.12);
+  border: 1px dashed rgba(241, 76, 76, 0.55);
+  color: var(--accent-red);
 }
 .blast-caller.pre-rename:hover,
 .blast-caller.pre-rename.highlighted {
   color: var(--text-primary);
-  border-color: #9fa8da;
-  background: rgba(92, 107, 192, 0.28);
-  box-shadow: 0 0 4px rgba(121, 134, 203, 0.35);
+  border-color: var(--accent-red);
+  background: rgba(241, 76, 76, 0.28);
+  box-shadow: 0 0 4px rgba(241, 76, 76, 0.4);
 }
 
 /* Two-column blast panel layout: details (left) + sunburst chart (right) */
@@ -3371,71 +3373,6 @@ body {
 .blast-score-mode-toggle button.active {
   background: var(--accent-blue);
   color: #fff;
-}
-
-/* Before/After call-graph switch, shown only for renamed symbols. Sits under
-   the Sunburst/Flamegraph switch and governs the chart only - the caller list
-   on the left keeps the full grouped inventory. */
-.blast-rename-toggle {
-  display: flex;
-  align-items: center;
-  gap: 1px;
-  margin-bottom: 6px;
-}
-
-.blast-rename-toggle-label {
-  margin-right: 6px;
-  color: var(--text-dim);
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.blast-rename-toggle button {
-  appearance: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 3px 9px;
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-secondary);
-  color: var(--text-dim);
-  font-size: 11px;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  cursor: pointer;
-  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
-}
-
-.blast-rename-toggle button:first-of-type {
-  border-radius: 4px 0 0 4px;
-}
-
-.blast-rename-toggle button:last-of-type {
-  border-radius: 0 4px 4px 0;
-}
-
-.blast-rename-toggle button:hover {
-  color: var(--text-secondary);
-}
-
-/* Indigo when active, matching the pre-rename styling the Before graph uses */
-.blast-rename-toggle button.active {
-  background: rgba(92, 107, 192, 0.3);
-  border-color: #9fa8da;
-  color: #e8eaf6;
-}
-
-.blast-rename-toggle-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 15px;
-  padding: 0 4px;
-  border-radius: 999px;
-  background: rgba(148, 163, 184, 0.18);
-  font-size: 9px;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
 }
 
 /* Symbol navigation bar */

--- a/internal/staticserve/static/styles.css
+++ b/internal/staticserve/static/styles.css
@@ -3238,6 +3238,30 @@ body {
   box-shadow: 0 0 4px rgba(255, 87, 34, 0.2);
 }
 
+/* Pre-rename callers: they reference the symbol's OLD name and break until
+   migrated, so they get the same cool/indigo treatment the charts use for
+   them (PRERENAME_COLORS in callgraph-utils.js) rather than reading as
+   ordinary live callers. */
+.blast-caller-group.pre-rename .blast-caller-group-header {
+  color: #9fa8da;
+}
+.blast-caller-group.pre-rename .blast-caller-count {
+  background: rgba(92, 107, 192, 0.22);
+  color: #c5cae9;
+}
+.blast-caller.pre-rename {
+  background: rgba(92, 107, 192, 0.12);
+  border: 1px dashed rgba(159, 168, 218, 0.55);
+  color: #b6bde0;
+}
+.blast-caller.pre-rename:hover,
+.blast-caller.pre-rename.highlighted {
+  color: var(--text-primary);
+  border-color: #9fa8da;
+  background: rgba(92, 107, 192, 0.28);
+  box-shadow: 0 0 4px rgba(121, 134, 203, 0.35);
+}
+
 /* Two-column blast panel layout: details (left) + sunburst chart (right) */
 .blast-panel-columns {
   display: flex;
@@ -3347,6 +3371,71 @@ body {
 .blast-score-mode-toggle button.active {
   background: var(--accent-blue);
   color: #fff;
+}
+
+/* Before/After call-graph switch, shown only for renamed symbols. Sits under
+   the Sunburst/Flamegraph switch and governs the chart only - the caller list
+   on the left keeps the full grouped inventory. */
+.blast-rename-toggle {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  margin-bottom: 6px;
+}
+
+.blast-rename-toggle-label {
+  margin-right: 6px;
+  color: var(--text-dim);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.blast-rename-toggle button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-secondary);
+  color: var(--text-dim);
+  font-size: 11px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.blast-rename-toggle button:first-of-type {
+  border-radius: 4px 0 0 4px;
+}
+
+.blast-rename-toggle button:last-of-type {
+  border-radius: 0 4px 4px 0;
+}
+
+.blast-rename-toggle button:hover {
+  color: var(--text-secondary);
+}
+
+/* Indigo when active, matching the pre-rename styling the Before graph uses */
+.blast-rename-toggle button.active {
+  background: rgba(92, 107, 192, 0.3);
+  border-color: #9fa8da;
+  color: #e8eaf6;
+}
+
+.blast-rename-toggle-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 15px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  font-size: 9px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
 }
 
 /* Symbol navigation bar */


### PR DESCRIPTION
## Summary

Renamed symbols are indexed against the post-rename tree, so a symbol like
`RunHelp` → `RuHelp` has zero CALLS edges to its old name — the graph engine
correctly finds no callers of `RuHelp` right after the rename. That made the
Sunburst/Flamegraph panel show "No callers in the dependency graph" for
exactly the hunks with the highest breakage risk (a rename with live callers
still on the old name).

This resolves old-name references via `search_code`'s compact mode (which maps
a grep hit back to its enclosing graph node) and surfaces them as their own
call graph, alongside the real post-rename one:

- `client.SearchCodeSymbols` — new client method, `search_code --mode compact`
- `oldNameCallers` / `expandPreRenameCallers` (`blastradius/rename.go`) —
  synthesize a `CallerRef` list for the old name, with one hop of transitive
  fan-in reused via the existing `score.FanIn`
- `CallerRef.PreRename` / `SymbolContribution.RenamedFrom` wired into both the
  `"calls"` and `"text-references"` scoring paths — **scoring itself is
  unchanged**: `BlastRadiusRaw`, `Signals`, and point values are identical to
  before this change
- A **Before/After** toggle in the panel (only shown for renamed symbols) lets
  you switch between "who still references the old name" and "who calls the
  new name in the current graph" — each labeled with its own count so an
  empty side reads as empty, not broken

Wording was deliberately kept to what's actually measured: a `search_code`
hit is grep-based and can be a real call, a comment, or a string literal, so
nothing here claims a reference "breaks" — only that it still exists.

## Test plan

- [x] `go build ./...` and `blastradius` package tests pass
      (`cd blastradius && go test ./ -count=1`)
- [x] `make test-js` — 96 tests pass, including new coverage for
      `callgraph_model.mjs` (grouping, Before/After split, wording)
- [x] End-to-end: `make build-local`, ran `lrc review --staged --force --serve`
      against a real rename diff (`func RunHelp()` → `func RuHelp()`), confirmed
      via the browser that both charts render the pre-rename caller and the
      Before/After toggle switches views correctly
- [x] Confirmed via `git stash` that two pre-existing failures in
      `blastradius/score/score_test.go` are unrelated to this change (they fail
      identically on a clean tree — their fake querier's Cypher match no longer
      lines up with the depth-specific queries `score.go` now emits)