### PR TITLE
Include branch name in review submission payload

### DIFF
--- a/internal/reviewapi/helpers.go
+++ b/internal/reviewapi/helpers.go
@@ -40,6 +40,21 @@ func CurrentTreeHash() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// CurrentBranchName returns the current git branch name, or "" if it cannot
+// be resolved (e.g. detached HEAD, or outside a git repo). Failures are
+// non-fatal since branch name is supplementary metadata for a review.
+func CurrentBranchName() string {
+	out, err := RunGitCommand("rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return ""
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == "HEAD" {
+		return ""
+	}
+	return branch
+}
+
 func resolveGitPath(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	out, err := cmd.Output()
@@ -148,6 +163,7 @@ func SubmitReview(apiURL, apiKey, base64Diff, repoName string, verbose bool) (re
 	payload := reviewmodel.DiffReviewRequest{
 		DiffZipBase64: base64Diff,
 		RepoName:      repoName,
+		BranchName:    CurrentBranchName(),
 	}
 
 	if verbose {

--- a/internal/reviewmodel/types.go
+++ b/internal/reviewmodel/types.go
@@ -38,6 +38,7 @@ type APIErrorPayload struct {
 type DiffReviewRequest struct {
 	DiffZipBase64 string `json:"diff_zip_base64"`
 	RepoName      string `json:"repo_name"`
+	BranchName    string `json:"branch_name"`
 }
 
 // DiffReviewResponse models the response from GET /api/v1/diff-review/:id.


### PR DESCRIPTION
The diff-review submission never sent the current git branch name to LiveReview, so CLI-sourced reviews always showed "-" for Branch in the dashboard. Resolve HEAD's branch and include it in the request.

## Summary

Describe what changed and why.

## Linked Issue

Link the agreed issue this PR fulfills.

## Validation

Describe the most specific test or validation you ran.

## Checklist

- [ ] This PR fulfills an agreed issue.
- [ ] I kept the change narrow and scoped.
- [ ] I ran the most specific relevant validation and described it above.
- [ ] If I changed behavior, I called that out clearly in this PR.
- [ ] If I touched UI, I attached a GIF or video walkthrough. This is required.
- [ ] If I changed `storage/` responsibilities, I updated `storage/storage_status.md` and ran `make check-status-doc`.
- [ ] If I changed `network/` responsibilities, I updated `network/network_status.md` and ran `make check-status-doc`.
- [ ] If this change touches security, disclosure flow, credentials, storage, network behavior, or remote data handling, I reviewed `SECURITY.md` and updated related documentation if needed.

## Notes For Reviewers

Anything specific you want reviewers to focus on.